### PR TITLE
feat(profiles): 3rd-party API endpoints via per-profile env

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ aimux profile update w -m claude-opus-4-6
 aimux run w
 ```
 
+### You want to connect a 3rd-party / self-hosted API endpoint
+
+```bash
+aimux profile add myapi --api
+# Configure API endpoint (leave blank to use default):
+#   Base URL:                          https://api.your-provider.com/v1
+#   Auth token:                        [hidden]
+#   Default model [claude-sonnet-4-6]:
+#   Opus model    [claude-opus-4-6]:
+#   Sonnet model  [claude-sonnet-4-6]:
+#   Haiku model   [claude-haiku-4-5]:
+# ✓ Credentials saved to ~/.aimux/profiles/myapi/.env (chmod 600)
+aimux run myapi
+```
+
+See [Per-profile environment variables](#per-profile-environment-variables) for the declarative alternative (`.env` file / `env:` block) used by power users and CI.
+
 ### Fresh machine (nothing installed)
 
 ```bash
@@ -90,7 +107,10 @@ aimux profile update o -m "claude-opus-4-6[1m]"
 | `aimux run work -m claude-sonnet-4-6` | Launch with model override |
 | `aimux agents` | Multi-profile agent view — see and manage claude background sessions across **all** profiles in one TUI |
 | `aimux profile add <name>` | Create new profile with symlinks |
+| `aimux profile add <name> --api` | Create a 3rd-party API profile (interactive endpoint + token prompt) |
 | `aimux profile update <name>` | Update model/cli settings |
+| `aimux profile update <name> -e KEY=VALUE` | Set an env var in the profile `.env` file |
+| `aimux profile update <name> --unset-env KEY` | Remove an env var from the profile `.env` file |
 | `aimux profile list` | List all profiles |
 | `aimux profile remove <name>` | Remove profile and clean up |
 | `aimux profile clone <src> <name>` | Clone profile with private files |
@@ -129,6 +149,34 @@ All profile commands support **prefix matching**: `aimux run w` → `work`, `aim
 
 When you run `aimux run work`, it sets `CLAUDE_CONFIG_DIR=~/.aimux/profiles/work` and launches the CLI. Claude sees a complete config directory — shared content via symlinks, private auth locally.
 
+## Per-profile environment variables
+
+Some Claude Code modes (3rd-party proxies, self-hosted gateways, Bedrock, Vertex) are activated by environment variables rather than OAuth. aimux injects per-profile env into the spawned `claude` process (and into `aimux auth login <profile>`) from two sources, merged in this order:
+
+1. **`<profile>/.env`** — a dotenv file inside the profile directory. Best for secrets. Written with `chmod 600` when aimux creates it; `aimux run` warns if it becomes group/other-readable.
+2. **`env:` block under the profile in `config.yaml`** — best for non-secret toggles you want versioned. **Overrides `.env`** on key conflict.
+
+The fastest way to set up an API profile is the interactive prompt:
+
+```bash
+aimux profile add myapi --api      # prompts for Base URL, hidden token, models
+aimux profile update myapi -e ANTHROPIC_MODEL=claude-opus-4-6   # edit later
+```
+
+…which writes something like:
+
+```bash
+# ~/.aimux/profiles/myapi/.env — do not commit
+ANTHROPIC_BASE_URL=https://api.your-provider.com/v1
+ANTHROPIC_AUTH_TOKEN=sk-your-token...
+ANTHROPIC_MODEL=claude-sonnet-4-6
+ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6
+ANTHROPIC_DEFAULT_SONNET_MODEL=claude-sonnet-4-6
+ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-haiku-4-5
+```
+
+The `.env` parser supports `KEY=value`, `export KEY=value`, comments, and single/double-quoted values (with `\n`/`\t` escapes inside double quotes). It does **not** do `${VAR}` interpolation or multi-line values — it's a secrets loader, not a full `dotenv-expand`. `.env` is always private (never symlinked to the shared source).
+
 ## Config
 
 ```yaml
@@ -145,13 +193,17 @@ profiles:
     cli: claude
     model: claude-opus-4-6
     path: /home/user/.aimux/profiles/work
-  own:
+  myapi:
     cli: claude
-    model: claude-opus-4-6
-    path: /home/user/.aimux/profiles/own
+    model: claude-sonnet-4-6
+    path: /home/user/.aimux/profiles/myapi   # secrets live in this dir's .env
+    # Optional non-secret env injected into the spawned CLI (overrides .env).
+    # env:
+    #   ANTHROPIC_DEFAULT_OPUS_MODEL: claude-opus-4-6
 
 private:
   - .credentials.json
+  - .env                  # API credentials — never symlinked, never committed
   - .claude.json
   - policy-limits.json
   - mcp-needs-auth-cache.json

--- a/docs/design/2026-04-19-aimux-design.md
+++ b/docs/design/2026-04-19-aimux-design.md
@@ -121,6 +121,7 @@ aimux run main
 | Element | Reason |
 |---------|--------|
 | `.credentials.json` | OAuth tokens per subscription |
+| `.env` | 3rd-party API credentials (ANTHROPIC_BASE_URL, ANTHROPIC_AUTH_TOKEN, …) — chmod 600 |
 | `.claude.json` | Session/account state |
 | `policy-limits.json` | Rate limits per subscription |
 | `mcp-needs-auth-cache.json` | MCP auth per account |
@@ -190,6 +191,13 @@ Interactive migration wizard:
 2. Creates symlinks to shared source for all shared elements
 3. Optionally triggers auth (`--no-auth` to skip)
 4. Updates `config.yaml`
+
+**`--api` flag — 3rd-party API endpoint:**
+1. Prompts (interactively, before any disk mutation) for Base URL, auth token (no echo), and per-tier models
+2. Writes `~/.aimux/profiles/<name>/.env` with `chmod 600` — credentials never touch `config.yaml` or shell history
+3. Skips OAuth — the profile authenticates via `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` env at launch
+
+Env injection (both `aimux run` and `aimux auth login`) merges `<profile>/.env` with an optional `env:` block in `config.yaml`; the YAML block wins on conflict. `aimux profile update -e KEY=VALUE / --unset-env KEY` edits the `.env` file in place.
 
 ### 4.3 `aimux profile list`
 Shows all profiles with status:

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -13,7 +13,12 @@ import {
   launchProfile, getLastProfile, recordHistory, getProfile,
   looksLikeSubcommand,
   summarizeUsage, parseSinceDuration, totalTokens,
+  loadProfileEnv, collectApiCredentials, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson,
 } from './core/index.js';
+
+function collectRepeatable(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
 
 function requireConfig(): AimuxConfig {
   const config = loadConfig();
@@ -224,6 +229,10 @@ program
 
       if (!launchingSubcommand) {
         recordHistory(process.cwd(), profileName);
+      }
+      const permWarning = checkDotenvPermissions(expandHome(config.profiles[profileName].path));
+      if (permWarning) {
+        console.error(`\x1b[33m⚠ ${permWarning}\x1b[0m`);
       }
       const exitCode = await launchProfile(config, profileName, { model: options.model, extraArgs: cliArgs });
       process.exit(exitCode);
@@ -480,14 +489,30 @@ program
       .argument('<name>', 'Profile name')
       .option('--no-auth', 'Skip authentication')
       .option('-m, --model <model>', 'Default model for this profile')
+      .option('--api', 'Configure a 3rd-party API endpoint instead of a Claude subscription')
       .description('Add a new profile')
-      .action((name: string, options: { auth: boolean; model?: string }) => {
+      .action(async (name: string, options: { auth: boolean; model?: string; api?: boolean }) => {
         try {
-          let config = requireConfig();
-          config = addProfile(config, name, { model: options.model });
-          saveConfig(config);
-          ensureProfileDir(config, name);
-          const sync = syncProfile(config, name);
+          const config = requireConfig();
+
+          // Reject a duplicate name up front so the user isn't asked to type a
+          // token blind only to hit "already exists" after the prompts.
+          if (config.profiles[name]) {
+            throw new Error(`Profile '${name}' already exists`);
+          }
+
+          // Collect credentials BEFORE mutating config/disk so a Ctrl+C
+          // mid-prompt leaves no half-created profile behind.
+          let apiVars: Record<string, string> | undefined;
+          if (options.api) {
+            console.log('Configure API endpoint (leave blank to use default):');
+            apiVars = await collectApiCredentials();
+          }
+
+          const updated = addProfile(config, name, { model: options.model });
+          saveConfig(updated);
+          const profilePath = ensureProfileDir(updated, name);
+          const sync = syncProfile(updated, name);
           console.log(`✓ Profile '${name}' created`);
           if (sync.created.length > 0) {
             console.log(`  ${sync.created.length} symlinks created`);
@@ -495,7 +520,15 @@ program
           if (sync.conflicts.length > 0) {
             console.log(`  conflicts left unchanged: ${sync.conflicts.join(', ')}`);
           }
-          if (!options.auth) {
+
+          if (apiVars) {
+            writeProfileDotEnv(profilePath, apiVars);
+            console.log(`  Credentials saved to ${join(profilePath, '.env')} (chmod 600)`);
+            if (seedApiClaudeJson(profilePath)) {
+              console.log('  Seeded .claude.json (skips Claude Code onboarding)');
+            }
+            console.log(`  Run: aimux run ${name}`);
+          } else if (!options.auth) {
             console.log('  Auth skipped (--no-auth). Run: aimux auth login ' + name);
           } else {
             console.log('  Run: aimux auth login ' + name);
@@ -520,19 +553,29 @@ program
       .argument('<name>', 'Profile name')
       .option('-m, --model <model>', 'Set default model')
       .option('--cli <cli>', 'Set CLI command')
+      .option('-e, --env <KEY=VALUE>', 'Set an env var in the profile .env file (repeatable)', collectRepeatable, [])
+      .option('--unset-env <KEY>', 'Remove an env var from the profile .env file (repeatable)', collectRepeatable, [])
       .description('Update profile settings')
-      .action((name: string, options: { model?: string; cli?: string }) => {
+      .action((name: string, options: { model?: string; cli?: string; env: string[]; unsetEnv: string[] }) => {
         try {
-          let config = requireConfig();
+          const config = requireConfig();
           const resolved = resolveProfile(config, name);
           const profile = config.profiles[resolved];
           if (options.model) profile.model = options.model;
           if (options.cli) profile.cli = options.cli;
           config.profiles[resolved] = profile;
           saveConfig(config);
+
+          let envChange: { set: string[]; unset: string[] } | undefined;
+          if (options.env.length > 0 || options.unsetEnv.length > 0) {
+            envChange = mergeProfileDotEnv(expandHome(profile.path), options.env, options.unsetEnv);
+          }
+
           console.log(`✓ Profile '${resolved}' updated`);
           if (options.model) console.log(`  model: ${options.model}`);
           if (options.cli) console.log(`  cli: ${options.cli}`);
+          if (envChange?.set.length) console.log(`  .env set: ${envChange.set.join(', ')}`);
+          if (envChange?.unset.length) console.log(`  .env unset: ${envChange.unset.join(', ')}`);
         } catch (err) {
           console.error(`Error: ${(err as Error).message}`);
           process.exit(1);
@@ -684,9 +727,13 @@ program
           const resolved = resolveProfile(config, profile);
           const p = getProfile(config, resolved);
           const profilePath = expandHome(p.path);
-          const env: Record<string, string> = {};
+          const env: Record<string, string> = loadProfileEnv(p, profilePath);
           if (!p.is_source) {
             env.CLAUDE_CONFIG_DIR = profilePath;
+          }
+          const permWarning = checkDotenvPermissions(profilePath);
+          if (permWarning) {
+            console.error(`\x1b[33m⚠ ${permWarning}\x1b[0m`);
           }
           console.log(`Launching auth for profile '${resolved}'...`);
           const result = spawnSync(p.cli, ['auth', 'login'], {

--- a/src/components/StatusView.tsx
+++ b/src/components/StatusView.tsx
@@ -4,29 +4,55 @@ import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 import { expandHome } from '../core/paths.js';
+import { loadProfileEnv } from '../core/run.js';
 import { getSharedElements, checkAllProfiles } from '../core/symlinks.js';
 
 interface Props {
   config: AimuxConfig;
 }
 
-function checkAuth(profile: ProfileConfig): boolean {
+type AuthStatus =
+  | { kind: 'oauth'; active: boolean }
+  | { kind: 'api'; varCount: number }
+  | { kind: 'none' };
+
+function isAuthenticated(status: AuthStatus): boolean {
+  return status.kind === 'api' || (status.kind === 'oauth' && status.active);
+}
+
+function checkAuth(profile: ProfileConfig): AuthStatus {
   const profilePath = expandHome(profile.path);
-  if (existsSync(join(profilePath, '.credentials.json'))) return true;
-  const env: Record<string, string> = {};
+
+  // A non-source profile pointing at a 3rd-party API endpoint authenticates
+  // via env (ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN), not OAuth. The source
+  // profile is the user's real ~/.claude and is always treated as a
+  // subscription regardless of any stray .env it may carry.
   if (!profile.is_source) {
-    env.CLAUDE_CONFIG_DIR = profilePath;
+    const env = loadProfileEnv(profile, profilePath);
+    if (env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_BASE_URL) {
+      return { kind: 'api', varCount: Object.keys(env).length };
+    }
+  }
+
+  if (existsSync(join(profilePath, '.credentials.json'))) {
+    return { kind: 'oauth', active: true };
+  }
+
+  const probeEnv: Record<string, string> = {};
+  if (!profile.is_source) {
+    probeEnv.CLAUDE_CONFIG_DIR = profilePath;
   }
   try {
     const result = spawnSync(profile.cli, ['auth', 'status'], {
-      env: { ...process.env, ...env },
+      env: { ...process.env, ...probeEnv },
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     const output = result.stdout?.toString() ?? '';
-    return output.includes('"loggedIn": true') || output.includes('"loggedIn":true');
+    const active = output.includes('"loggedIn": true') || output.includes('"loggedIn":true');
+    return { kind: 'oauth', active };
   } catch {
-    return false;
+    return { kind: 'none' };
   }
 }
 
@@ -41,7 +67,7 @@ function safeGetSharedElements(config: AimuxConfig): string[] {
 export function StatusView({ config }: Props) {
   const profiles = Object.entries(config.profiles);
   const authStatuses = new Map(profiles.map(([name, profile]) => [name, checkAuth(profile)]));
-  const authCount = Array.from(authStatuses.values()).filter(Boolean).length;
+  const authCount = Array.from(authStatuses.values()).filter(isAuthenticated).length;
   const sharedEntries = safeGetSharedElements(config);
   const sharedCount = sharedEntries.length;
   const reports = checkAllProfiles(config);
@@ -60,13 +86,14 @@ export function StatusView({ config }: Props) {
         <Box flexDirection="column">
           <Box gap={2}>
             <Box width={12}><Text bold underline>NAME</Text></Box>
-            <Box width={14}><Text bold underline>AUTH</Text></Box>
+            <Box width={16}><Text bold underline>AUTH</Text></Box>
             <Box width={20}><Text bold underline>MODEL</Text></Box>
             <Box width={18}><Text bold underline>SHARED</Text></Box>
           </Box>
 
           {profiles.map(([name, profile]) => {
-            const authed = authStatuses.get(name) ?? false;
+            const auth = authStatuses.get(name) ?? { kind: 'none' as const };
+            const authed = isAuthenticated(auth);
             const isSource = profile.is_source ?? false;
             const report = reports.get(name);
             const healthyShared = isSource ? sharedCount : report?.valid.length ?? 0;
@@ -90,10 +117,11 @@ export function StatusView({ config }: Props) {
                 <Box width={12}>
                   <Text color={isSource ? 'yellow' : 'white'}>{name}</Text>
                 </Box>
-                <Box width={14}>
-                  <Text color={authed ? 'green' : 'red'}>
-                    {authed ? '✓ active' : '✗ no auth'}
-                  </Text>
+                <Box width={16}>
+                  {auth.kind === 'api'
+                    ? <Text color="cyan">✓ api ({auth.varCount} vars)</Text>
+                    : <Text color={authed ? 'green' : 'red'}>{authed ? '✓ oauth' : '✗ no auth'}</Text>
+                  }
                 </Box>
                 <Box width={20}>
                   <Text dimColor>{profile.model ?? 'default'}</Text>

--- a/src/core/apiProfile.test.ts
+++ b/src/core/apiProfile.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions } from './apiProfile.js';
+import { parseDotenv } from './run.js';
+
+describe('writeProfileDotEnv', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'aimux-write-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('writes a parseable .env round-trip', () => {
+    writeProfileDotEnv(dir, { ANTHROPIC_BASE_URL: 'https://api.example.com/v1', ANTHROPIC_AUTH_TOKEN: 'sk-123' });
+    const parsed = parseDotenv(readFileSync(join(dir, '.env'), 'utf-8'));
+    expect(parsed.ANTHROPIC_BASE_URL).toBe('https://api.example.com/v1');
+    expect(parsed.ANTHROPIC_AUTH_TOKEN).toBe('sk-123');
+  });
+
+  it('writes the file with 0600 permissions', () => {
+    writeProfileDotEnv(dir, { FOO: 'bar' });
+    const mode = statSync(join(dir, '.env')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('quotes and round-trips values containing spaces or hashes', () => {
+    writeProfileDotEnv(dir, { MSG: 'hello world # ok' });
+    const parsed = parseDotenv(readFileSync(join(dir, '.env'), 'utf-8'));
+    expect(parsed.MSG).toBe('hello world # ok');
+  });
+
+  it('round-trips values containing CR and LF', () => {
+    writeProfileDotEnv(dir, { MULTI: 'line1\r\nline2' });
+    const parsed = parseDotenv(readFileSync(join(dir, '.env'), 'utf-8'));
+    expect(parsed.MULTI).toBe('line1\r\nline2');
+  });
+});
+
+describe('mergeProfileDotEnv', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'aimux-merge-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('sets new keys while preserving existing ones', () => {
+    writeProfileDotEnv(dir, { A: '1' });
+    const change = mergeProfileDotEnv(dir, ['B=2'], []);
+    const parsed = parseDotenv(readFileSync(join(dir, '.env'), 'utf-8'));
+    expect(parsed).toEqual({ A: '1', B: '2' });
+    expect(change.set).toEqual(['B']);
+  });
+
+  it('unsets keys', () => {
+    writeProfileDotEnv(dir, { A: '1', B: '2' });
+    mergeProfileDotEnv(dir, [], ['A']);
+    const parsed = parseDotenv(readFileSync(join(dir, '.env'), 'utf-8'));
+    expect(parsed).toEqual({ B: '2' });
+  });
+
+  it('rejects malformed assignments', () => {
+    expect(() => mergeProfileDotEnv(dir, ['NOEQUALS'], [])).toThrow('expected KEY=VALUE');
+  });
+
+  it('tightens permissions to 0600 when overwriting a looser existing .env', () => {
+    // Simulate a hand-written / #3-style 0644 file, then merge into it.
+    writeFileSync(join(dir, '.env'), 'A=1\n', { mode: 0o644 });
+    chmodSync(join(dir, '.env'), 0o644);
+    mergeProfileDotEnv(dir, ['B=2'], []);
+    expect(statSync(join(dir, '.env')).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('checkDotenvPermissions', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'aimux-perm-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('returns null when there is no .env', () => {
+    expect(checkDotenvPermissions(dir)).toBeNull();
+  });
+
+  it('returns null for 0600', () => {
+    writeProfileDotEnv(dir, { A: '1' });
+    expect(checkDotenvPermissions(dir)).toBeNull();
+  });
+
+  it('warns when group/other can read the file', () => {
+    writeFileSync(join(dir, '.env'), 'A=1\n');
+    chmodSync(join(dir, '.env'), 0o644);
+    const warning = checkDotenvPermissions(dir);
+    expect(warning).toContain('chmod 600');
+  });
+});

--- a/src/core/apiProfile.ts
+++ b/src/core/apiProfile.ts
@@ -1,0 +1,261 @@
+import { writeFileSync, readFileSync, existsSync, statSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseDotenv } from './run.js';
+
+/**
+ * Default Claude model IDs offered when configuring a 3rd-party API profile.
+ * Used both as the prompt placeholders and as the fallback when the user
+ * accepts the default by entering nothing.
+ */
+export const API_MODEL_DEFAULTS = {
+  ANTHROPIC_MODEL: 'claude-sonnet-4-6',
+  ANTHROPIC_DEFAULT_OPUS_MODEL: 'claude-opus-4-6',
+  ANTHROPIC_DEFAULT_SONNET_MODEL: 'claude-sonnet-4-6',
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-haiku-4-5',
+} as const;
+
+/**
+ * Sequential line reader over a single stdin consumer. Reading multiple
+ * prompts via repeated `readline.createInterface()` drops buffered input on
+ * close (breaks piped/non-TTY), and muting readline's output writer stalls
+ * its `question()` promise on Node 22+. This reader owns one `data` handler
+ * and an explicit buffer, so no line is ever lost and secrets can be masked.
+ *
+ * - TTY: raw mode, echoes printable input (masked with `*` when `secret`),
+ *   handles Enter, Backspace/Delete, and Ctrl+C.
+ * - non-TTY (pipes/tests): splits incoming chunks on newlines; masking is a
+ *   no-op since nothing is echoed.
+ */
+class StdinLineReader {
+  private readonly stdin = process.stdin;
+  private readonly isTTY = Boolean(process.stdin.isTTY);
+  private buffer = '';
+  private readonly completed: string[] = [];
+  private waiter: { secret: boolean; resolve: (line: string) => void } | null = null;
+  private attached = false;
+
+  private ended = false;
+  private lastWasCR = false;
+
+  private readonly onData = (chunk: string): void => {
+    if (this.isTTY) {
+      this.consumeTty(chunk);
+    } else {
+      this.buffer += chunk;
+      let nl: number;
+      while ((nl = this.buffer.indexOf('\n')) >= 0) {
+        this.completed.push(this.buffer.slice(0, nl).replace(/\r$/, ''));
+        this.buffer = this.buffer.slice(nl + 1);
+      }
+    }
+    this.flush();
+  };
+
+  // On EOF (piped input with no trailing newline), surface the last partial
+  // line and let any still-pending prompts resolve empty so defaults apply.
+  private readonly onEnd = (): void => {
+    this.ended = true;
+    if (this.buffer.length > 0) {
+      this.completed.push(this.buffer);
+      this.buffer = '';
+    }
+    this.flush();
+  };
+
+  private consumeTty(chunk: string): void {
+    for (const ch of chunk) {
+      const wasCR = this.lastWasCR;
+      this.lastWasCR = false;
+      if (ch === '\r' || ch === '\n') {
+        // Coalesce CRLF: a '\n' right after a '\r' is the same Enter press,
+        // not a second (empty) line. Without this the next prompt resolves
+        // empty and every later answer shifts up by one field.
+        if (ch === '\n' && wasCR) continue;
+        this.lastWasCR = ch === '\r';
+        process.stdout.write('\n');
+        this.completed.push(this.buffer);
+        this.buffer = '';
+      } else if (ch === '\u0003') { // Ctrl+C
+        this.detach();
+        process.exit(130);
+      } else if (ch === '\u007f' || ch === '\b') {
+        if (this.buffer.length > 0) {
+          this.buffer = this.buffer.slice(0, -1);
+          if (!this.waiter?.secret) process.stdout.write('\b \b');
+        }
+      } else if (ch >= ' ') {
+        this.buffer += ch;
+        process.stdout.write(this.waiter?.secret ? '*' : ch);
+      }
+    }
+  }
+
+  private flush(): void {
+    while (this.waiter && this.completed.length > 0) {
+      const { resolve } = this.waiter;
+      this.waiter = null;
+      resolve(this.completed.shift()!);
+    }
+    if (this.ended && this.waiter) {
+      const { resolve } = this.waiter;
+      this.waiter = null;
+      resolve('');
+    }
+  }
+
+  private attach(): void {
+    if (this.attached) return;
+    this.attached = true;
+    if (this.isTTY) this.stdin.setRawMode(true);
+    this.stdin.resume();
+    this.stdin.setEncoding('utf8');
+    this.stdin.on('data', this.onData);
+    this.stdin.on('end', this.onEnd);
+  }
+
+  private detach(): void {
+    if (!this.attached) return;
+    this.attached = false;
+    this.stdin.removeListener('data', this.onData);
+    this.stdin.removeListener('end', this.onEnd);
+    if (this.isTTY) this.stdin.setRawMode(false);
+    this.stdin.pause();
+  }
+
+  question(query: string, secret = false): Promise<string> {
+    this.attach();
+    process.stdout.write(query);
+    return new Promise((resolve) => {
+      this.waiter = { secret, resolve: (line) => resolve(line.trim()) };
+      this.flush();
+    });
+  }
+
+  close(): void {
+    this.detach();
+  }
+}
+
+/**
+ * Interactively collect 3rd-party API endpoint credentials. Returns the env
+ * var map to persist to the profile's `.env`. The auth token is read with no
+ * echo; model fields fall back to {@link API_MODEL_DEFAULTS} when left blank.
+ */
+export async function collectApiCredentials(): Promise<Record<string, string>> {
+  // label is padded so the `[default]` hints line up in the terminal.
+  const MODEL_PROMPTS: ReadonlyArray<[key: keyof typeof API_MODEL_DEFAULTS, label: string]> = [
+    ['ANTHROPIC_MODEL', 'Default model'],
+    ['ANTHROPIC_DEFAULT_OPUS_MODEL', 'Opus model   '],
+    ['ANTHROPIC_DEFAULT_SONNET_MODEL', 'Sonnet model '],
+    ['ANTHROPIC_DEFAULT_HAIKU_MODEL', 'Haiku model  '],
+  ];
+
+  const reader = new StdinLineReader();
+  try {
+    const vars: Record<string, string> = {};
+
+    const baseUrl = await reader.question('  Base URL:                          ');
+    if (baseUrl) vars.ANTHROPIC_BASE_URL = baseUrl;
+
+    const authToken = await reader.question('  Auth token:                        ', true);
+    if (authToken) vars.ANTHROPIC_AUTH_TOKEN = authToken;
+
+    for (const [key, label] of MODEL_PROMPTS) {
+      const fallback = API_MODEL_DEFAULTS[key];
+      const answer = await reader.question(`  ${label} [${fallback}]: `);
+      vars[key] = answer || fallback;
+    }
+
+    return vars;
+  } finally {
+    reader.close();
+  }
+}
+
+/**
+ * Seed a minimal `.claude.json` for an API profile so Claude Code skips its
+ * first-run onboarding/OAuth flow and goes straight to the API endpoint
+ * configured via env. No-op if the file already exists (never clobbers a real
+ * one). Written chmod 600 alongside the profile's `.env`.
+ */
+export function seedApiClaudeJson(profilePath: string): boolean {
+  const target = join(profilePath, '.claude.json');
+  if (existsSync(target)) return false;
+  writeFileSync(target, JSON.stringify({ hasCompletedOnboarding: true }, null, 2) + '\n', {
+    encoding: 'utf-8',
+    mode: 0o600,
+  });
+  return true;
+}
+
+/** Quote a dotenv value only when it contains characters that need it. */
+function serializeDotenvValue(value: string): string {
+  if (/^[A-Za-z0-9_./:@-]*$/.test(value)) return value;
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n');
+  return `"${escaped}"`;
+}
+
+/**
+ * Write a profile's `.env` file with `chmod 600` so secrets are not
+ * world-readable. Overwrites any existing file.
+ */
+export function writeProfileDotEnv(profilePath: string, vars: Record<string, string>): void {
+  const lines = ['# Generated by aimux — do not commit', ''];
+  for (const [key, value] of Object.entries(vars)) {
+    lines.push(`${key}=${serializeDotenvValue(value)}`);
+  }
+  const target = join(profilePath, '.env');
+  writeFileSync(target, lines.join('\n') + '\n', { encoding: 'utf-8', mode: 0o600 });
+  // writeFileSync's mode only applies on creation; chmod so an overwrite of an
+  // existing looser-permission file (e.g. a hand-written 0644 .env) is tightened too.
+  chmodSync(target, 0o600);
+}
+
+/**
+ * Apply `KEY=VALUE` sets and key unsets to a profile's `.env` file in place,
+ * preserving existing entries. Re-writes with `chmod 600`. Returns the keys
+ * that were set and unset for reporting.
+ */
+export function mergeProfileDotEnv(
+  profilePath: string,
+  set: string[],
+  unset: string[],
+): { set: string[]; unset: string[] } {
+  const dotenvPath = join(profilePath, '.env');
+  const vars = existsSync(dotenvPath) ? parseDotenv(readFileSync(dotenvPath, 'utf-8')) : {};
+
+  const setKeys: string[] = [];
+  for (const pair of set) {
+    const eq = pair.indexOf('=');
+    if (eq < 1) throw new Error(`Invalid env assignment '${pair}': expected KEY=VALUE`);
+    const key = pair.slice(0, eq).trim();
+    vars[key] = pair.slice(eq + 1);
+    setKeys.push(key);
+  }
+  for (const key of unset) delete vars[key];
+
+  writeProfileDotEnv(profilePath, vars);
+  return { set: setKeys, unset };
+}
+
+/**
+ * Return a warning string if the profile's `.env` is readable beyond the
+ * owner (mode has group/other bits set), else null. Lets callers nudge users
+ * toward `chmod 600` the way docker warns about loose key permissions.
+ */
+export function checkDotenvPermissions(profilePath: string): string | null {
+  const dotenvPath = join(profilePath, '.env');
+  try {
+    const mode = statSync(dotenvPath).mode & 0o777;
+    if (mode & 0o077) {
+      return `${dotenvPath} is readable by group/other (mode ${mode.toString(8).padStart(3, '0')}). Run: chmod 600 ${dotenvPath}`;
+    }
+  } catch {
+    // no .env or not stat-able — nothing to warn about
+  }
+  return null;
+}

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -136,6 +136,17 @@ export function validateConfig(config: unknown): string[] {
       if (p.model !== undefined && typeof p.model !== 'string') {
         errors.push(`Profile '${name}': model must be a string`);
       }
+      if (p.env !== undefined) {
+        if (!p.env || typeof p.env !== 'object' || Array.isArray(p.env)) {
+          errors.push(`Profile '${name}': env must be a map of string keys to string values`);
+        } else {
+          for (const [k, v] of Object.entries(p.env as Record<string, unknown>)) {
+            if (typeof v !== 'string') {
+              errors.push(`Profile '${name}': env.${k} must be a string`);
+            }
+          }
+        }
+      }
       if (p.is_source) sourceCount++;
     }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -44,8 +44,17 @@ export {
 
 export type { DetectedDir, InitResult } from './init.js';
 
-export { buildRunParams, launchProfile, looksLikeSubcommand } from './run.js';
+export { buildRunParams, launchProfile, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
 export type { RunOptions, RunParams } from './run.js';
+
+export {
+  collectApiCredentials,
+  writeProfileDotEnv,
+  mergeProfileDotEnv,
+  checkDotenvPermissions,
+  seedApiClaudeJson,
+  API_MODEL_DEFAULTS,
+} from './apiProfile.js';
 
 export { summarizeUsage, parseSinceDuration, totalTokens } from './usage.js';
 export type { ProfileUsageSummary, UsageOptions, UsageTotals } from './usage.js';

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -1,15 +1,18 @@
-import { describe, it, expect } from 'vitest';
-import { buildRunParams, looksLikeSubcommand } from './run.js';
-import type { AimuxConfig } from '../types/index.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildRunParams, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
+import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 
-function makeConfig(): AimuxConfig {
+function makeConfig(ownExtras?: Partial<ProfileConfig>): AimuxConfig {
   return {
     version: 1,
     shared_source: '/home/user/.claude',
     profiles: {
       main: { cli: 'claude', path: '/home/user/.claude', is_source: true },
       work: { cli: 'claude', path: '/home/user/.aimux/profiles/work', model: 'claude-opus-4-6' },
-      own: { cli: 'claude', path: '/home/user/.aimux/profiles/own' },
+      own: { cli: 'claude', path: '/home/user/.aimux/profiles/own', ...ownExtras },
     },
     private: ['.credentials.json'],
   };
@@ -82,6 +85,91 @@ describe('buildRunParams', () => {
     expect(modelFlags.length).toBe(1);
     expect(params.args).toContain('sonnet');
     expect(params.args).not.toContain('claude-opus-4-6');
+  });
+
+  it('forwards profile env block to the spawned process', () => {
+    const config = makeConfig({ env: { CLAUDE_CODE_USE_BEDROCK: '1', AWS_REGION: 'us-east-1' } });
+    const params = buildRunParams(config, 'own');
+    expect(params.env.CLAUDE_CODE_USE_BEDROCK).toBe('1');
+    expect(params.env.AWS_REGION).toBe('us-east-1');
+  });
+});
+
+describe('parseDotenv', () => {
+  it('parses basic KEY=VALUE pairs', () => {
+    expect(parseDotenv('FOO=bar\nBAZ=qux')).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('skips comments and blank lines', () => {
+    expect(parseDotenv('# a comment\n\nFOO=bar\n')).toEqual({ FOO: 'bar' });
+  });
+
+  it('supports the `export` prefix', () => {
+    expect(parseDotenv('export FOO=bar')).toEqual({ FOO: 'bar' });
+  });
+
+  it('strips matching surrounding quotes', () => {
+    expect(parseDotenv('FOO="bar baz"\nBAR=\'qux\'')).toEqual({ FOO: 'bar baz', BAR: 'qux' });
+  });
+
+  it('decodes escapes inside double quotes only', () => {
+    expect(parseDotenv('FOO="line1\\nline2"\nBAR=\'line1\\nline2\'')).toEqual({
+      FOO: 'line1\nline2',
+      BAR: 'line1\\nline2',
+    });
+  });
+
+  it('strips inline comments on unquoted values', () => {
+    expect(parseDotenv('FOO=bar # trailing\n')).toEqual({ FOO: 'bar' });
+  });
+
+  it('preserves `#` inside quoted values', () => {
+    expect(parseDotenv('FOO="bar # not a comment"')).toEqual({ FOO: 'bar # not a comment' });
+  });
+
+  it('strips inline comments AFTER a quoted value (PR #3 reviewer bug)', () => {
+    expect(parseDotenv('FOO="bar" # comment')).toEqual({ FOO: 'bar' });
+    expect(parseDotenv("BAR='qux'  # trailing")).toEqual({ BAR: 'qux' });
+  });
+
+  it('keeps a value that has an unterminated quote literal', () => {
+    expect(parseDotenv('FOO="bar')).toEqual({ FOO: '"bar' });
+  });
+
+  it('treats tab-before-hash as an inline comment', () => {
+    expect(parseDotenv('FOO=bar\t# comment')).toEqual({ FOO: 'bar' });
+  });
+
+  it('decodes \\r escapes inside double quotes', () => {
+    expect(parseDotenv('FOO="a\\rb"')).toEqual({ FOO: 'a\rb' });
+  });
+});
+
+describe('loadProfileEnv', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aimux-env-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads .env from the profile directory', () => {
+    writeFileSync(join(dir, '.env'), 'ANTHROPIC_AUTH_TOKEN=secret123\n');
+    const env = loadProfileEnv({ cli: 'claude', path: dir }, dir);
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('secret123');
+  });
+
+  it('lets the YAML env block override .env on key conflict', () => {
+    writeFileSync(join(dir, '.env'), 'ANTHROPIC_MODEL=from-dotenv\n');
+    const env = loadProfileEnv({ cli: 'claude', path: dir, env: { ANTHROPIC_MODEL: 'from-yaml' } }, dir);
+    expect(env.ANTHROPIC_MODEL).toBe('from-yaml');
+  });
+
+  it('returns an empty object when neither .env nor env block exist', () => {
+    expect(loadProfileEnv({ cli: 'claude', path: dir }, dir)).toEqual({});
   });
 });
 

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -1,11 +1,92 @@
 import { spawn } from 'node:child_process';
-import type { AimuxConfig } from '../types/index.js';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 import { getProfile } from './config.js';
 import { expandHome } from './paths.js';
 
 export interface RunOptions {
   model?: string;
   extraArgs?: string[];
+}
+
+const ENV_LINE = /^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/;
+
+const DOUBLE_QUOTE_ESCAPES: Record<string, string> = {
+  n: '\n',
+  r: '\r',
+  t: '\t',
+  '"': '"',
+  '\\': '\\',
+};
+
+/**
+ * Parse a single dotenv right-hand-side value.
+ *
+ * - Quoted values (`"..."` / `'...'`) end at the matching closing quote; any
+ *   trailing inline comment after the closing quote is discarded.
+ * - Double-quoted values decode `\n`, `\r`, `\t`, `\"`, `\\` escapes.
+ * - Single-quoted values are taken literally (no escape decoding).
+ * - Unquoted values strip a trailing ` #` inline comment.
+ *
+ * Note: `${VAR}` interpolation and multi-line values are NOT supported —
+ * this is a secrets-oriented loader, not a full dotenv-expand implementation.
+ */
+function parseDotenvValue(raw: string): string {
+  const quote = raw[0];
+  if (quote === '"' || quote === "'") {
+    let out = '';
+    for (let i = 1; i < raw.length; i++) {
+      const ch = raw[i];
+      if (quote === '"' && ch === '\\' && i + 1 < raw.length) {
+        const next = raw[i + 1];
+        out += DOUBLE_QUOTE_ESCAPES[next] ?? `\\${next}`;
+        i++;
+        continue;
+      }
+      if (ch === quote) return out; // closing quote — ignore any inline comment after it
+      out += ch;
+    }
+    return raw; // unterminated quote — treat the raw text literally
+  }
+  const inlineComment = raw.search(/\s#/); // whitespace + '#' starts a comment
+  return (inlineComment >= 0 ? raw.slice(0, inlineComment) : raw).trimEnd();
+}
+
+/**
+ * Parse the contents of a dotenv file into a key/value map.
+ *
+ * Supports `KEY=value`, `export KEY=value`, `# comments`, blank lines,
+ * single/double-quoted values, escape sequences inside double quotes only,
+ * and trailing inline comments on both quoted and unquoted values.
+ */
+export function parseDotenv(contents: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const trimmed = rawLine.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const match = ENV_LINE.exec(rawLine);
+    if (!match) continue;
+    result[match[1]] = parseDotenvValue(match[2]);
+  }
+  return result;
+}
+
+/**
+ * Resolve the environment variables injected into the spawned CLI for a
+ * profile. Merges the profile's `<path>/.env` dotenv file with the optional
+ * `env:` block from config.yaml; the YAML block wins on key conflict.
+ */
+export function loadProfileEnv(profile: ProfileConfig, profilePath: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  const dotenvPath = join(profilePath, '.env');
+  if (existsSync(dotenvPath)) {
+    Object.assign(env, parseDotenv(readFileSync(dotenvPath, 'utf-8')));
+  }
+  if (profile.env) {
+    Object.assign(env, profile.env);
+  }
+  return env;
 }
 
 export interface RunParams {
@@ -45,7 +126,7 @@ export function buildRunParams(
     args.push(...extraArgs);
   }
 
-  const env: Record<string, string> = {};
+  const env: Record<string, string> = loadProfileEnv(profile, profilePath);
   if (!profile.is_source) {
     env.CLAUDE_CONFIG_DIR = profilePath;
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -3,6 +3,8 @@ export interface ProfileConfig {
   model?: string;
   path: string;
   is_source?: boolean;
+  /** Non-secret env vars injected into the spawned CLI; overrides `.env` on conflict. */
+  env?: Record<string, string>;
 }
 
 export interface AimuxConfig {
@@ -14,6 +16,7 @@ export interface AimuxConfig {
 
 export const DEFAULT_PRIVATE_ELEMENTS = [
   '.credentials.json',
+  '.env',
   '.claude.json',
   '.last-cleanup',
   'policy-limits.json',


### PR DESCRIPTION
## What

Lets a profile point at a self-hosted / 3rd-party Claude-compatible API endpoint instead of an Anthropic subscription.

```bash
aimux profile add myapi --api      # interactive: Base URL, hidden token, per-tier models
aimux run myapi                    # injects env, no OAuth
```

## How

**Core (env injection)**
- `parseDotenv` + `loadProfileEnv` in `run.ts`: merge a profile's `<path>/.env` with an optional `config.yaml` `env:` block (YAML wins on conflict); injected into both `aimux run` and `aimux auth login`.
- `ProfileConfig.env` type + validation; `.env` added to `DEFAULT_PRIVATE_ELEMENTS` (never symlinked to the shared source).

**UX (`apiProfile.ts`, self-contained)**
- `aimux profile add --api`: interactive prompt; credentials collected **before** any disk write (Ctrl+C leaves no orphan); `.env` written `chmod 600`; seeds a minimal `.claude.json` so Claude Code skips onboarding/OAuth.
- `aimux profile update -e KEY=VALUE / --unset-env KEY` edits `.env` in place.
- `aimux run` warns when a profile `.env` is group/other-readable.
- `StatusView` distinguishes `oauth` vs `api (N vars)`.
- Custom single-consumer `StdinLineReader` for the prompt flow — avoids readline's lost-input / unsettled-promise quirks and CRLF double-line on Node 22+; masks the secret in TTY, handles piped input for CI.

## Relationship to #3

This overlaps with #3 (per-profile env via `.env`) and adopts the same core API surface (`parseDotenv` / `loadProfileEnv` / `env:` block) to keep the merge trivial. It additionally:
- addresses all three review notes on #3 — strips inline comments **after** quoted values (the `FOO="bar" # x` case), documents no `${VAR}`/multi-line, and adds the `chmod 600` + loose-permission runtime warning;
- layers the interactive `--api` UX, `.claude.json` seeding, and the oauth/api status distinction on top.

If #3 lands first, the core helpers dedupe trivially and this becomes the UX layer; if not, it stands alone.

## Tests

130 passing. New: `parseDotenv` (incl. quoted-comment + CRLF round-trip), `loadProfileEnv` override order, `writeProfileDotEnv` 0600 round-trip, `mergeProfileDotEnv`, permission check.

Closes #2
