### PR TITLE
feat(status): per-profile auto-mode posture column

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ aimux profile update o -m "claude-opus-4-6[1m]"
 |---------|-------------|
 | `aimux init` | Auto-detect Claude dirs, create config, migrate profiles |
 | `aimux init --source <path>` | Initialize with explicit source directory |
-| `aimux status` | TUI dashboard — profiles, auth, symlink health |
+| `aimux status` | TUI dashboard — profiles, auth, auto-mode posture, symlink health |
 | `aimux usage` | Show token usage by profile from Claude transcript metadata |
 | `aimux usage --profile work --since 24h` | Show usage for one profile over a recent window |
 | `aimux run [profile]` | Launch AI CLI with correct env and model |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/components/StatusView.tsx
+++ b/src/components/StatusView.tsx
@@ -5,6 +5,7 @@ import { spawnSync } from 'node:child_process';
 import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 import { expandHome } from '../core/paths.js';
 import { loadProfileEnv } from '../core/run.js';
+import { readProfileAutoMode } from '../core/autoMode.js';
 import { getSharedElements, checkAllProfiles } from '../core/symlinks.js';
 
 interface Props {
@@ -67,6 +68,9 @@ function safeGetSharedElements(config: AimuxConfig): string[] {
 export function StatusView({ config }: Props) {
   const profiles = Object.entries(config.profiles);
   const authStatuses = new Map(profiles.map(([name, profile]) => [name, checkAuth(profile)]));
+  const autoModes = new Map(
+    profiles.map(([name, profile]) => [name, readProfileAutoMode(expandHome(profile.path))]),
+  );
   const authCount = Array.from(authStatuses.values()).filter(isAuthenticated).length;
   const sharedEntries = safeGetSharedElements(config);
   const sharedCount = sharedEntries.length;
@@ -88,12 +92,14 @@ export function StatusView({ config }: Props) {
             <Box width={12}><Text bold underline>NAME</Text></Box>
             <Box width={16}><Text bold underline>AUTH</Text></Box>
             <Box width={20}><Text bold underline>MODEL</Text></Box>
+            <Box width={16}><Text bold underline>AUTOMODE</Text></Box>
             <Box width={18}><Text bold underline>SHARED</Text></Box>
           </Box>
 
           {profiles.map(([name, profile]) => {
             const auth = authStatuses.get(name) ?? { kind: 'none' as const };
             const authed = isAuthenticated(auth);
+            const autoMode = autoModes.get(name) ?? { configured: false, allowCount: 0, softDenyCount: 0 };
             const isSource = profile.is_source ?? false;
             const report = reports.get(name);
             const healthyShared = isSource ? sharedCount : report?.valid.length ?? 0;
@@ -125,6 +131,12 @@ export function StatusView({ config }: Props) {
                 </Box>
                 <Box width={20}>
                   <Text dimColor>{profile.model ?? 'default'}</Text>
+                </Box>
+                <Box width={16}>
+                  {autoMode.configured
+                    ? <Text color="cyan">✓ {autoMode.allowCount} allow</Text>
+                    : <Text dimColor>—</Text>
+                  }
                 </Box>
                 <Box width={18}>
                   <Text color={sharedColor}>

--- a/src/components/StatusView.tsx
+++ b/src/components/StatusView.tsx
@@ -1,4 +1,5 @@
 import { Box, Text } from 'ink';
+import { useMemo } from 'react';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -57,6 +58,10 @@ function checkAuth(profile: ProfileConfig): AuthStatus {
   }
 }
 
+function capCount(n: number): string {
+  return n > 99 ? '99+' : String(n);
+}
+
 function safeGetSharedElements(config: AimuxConfig): string[] {
   try {
     return getSharedElements(config);
@@ -68,8 +73,11 @@ function safeGetSharedElements(config: AimuxConfig): string[] {
 export function StatusView({ config }: Props) {
   const profiles = Object.entries(config.profiles);
   const authStatuses = new Map(profiles.map(([name, profile]) => [name, checkAuth(profile)]));
-  const autoModes = new Map(
-    profiles.map(([name, profile]) => [name, readProfileAutoMode(expandHome(profile.path))]),
+  // Memoized on config: each entry reads a settings.json synchronously, so we
+  // avoid re-reading every profile's file on every Ink re-render (resize/keypress).
+  const autoModes = useMemo(
+    () => new Map(profiles.map(([name, profile]) => [name, readProfileAutoMode(expandHome(profile.path))])),
+    [config],
   );
   const authCount = Array.from(authStatuses.values()).filter(isAuthenticated).length;
   const sharedEntries = safeGetSharedElements(config);
@@ -134,7 +142,7 @@ export function StatusView({ config }: Props) {
                 </Box>
                 <Box width={16}>
                   {autoMode.configured
-                    ? <Text color="cyan">✓ {autoMode.allowCount} allow</Text>
+                    ? <Text color="cyan">✓{capCount(autoMode.allowCount)} ✗{capCount(autoMode.softDenyCount)}</Text>
                     : <Text dimColor>—</Text>
                   }
                 </Box>

--- a/src/core/autoMode.test.ts
+++ b/src/core/autoMode.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readProfileAutoMode } from './autoMode.js';
+
+describe('readProfileAutoMode', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'aimux-automode-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  function writeSettings(value: unknown): void {
+    writeFileSync(join(dir, 'settings.json'), JSON.stringify(value));
+  }
+
+  it('reports not-configured when settings.json is missing', () => {
+    expect(readProfileAutoMode(dir)).toEqual({ configured: false, allowCount: 0, softDenyCount: 0 });
+  });
+
+  it('reports not-configured when there is no autoMode block', () => {
+    writeSettings({ model: 'claude-opus-4-6' });
+    expect(readProfileAutoMode(dir)).toEqual({ configured: false, allowCount: 0, softDenyCount: 0 });
+  });
+
+  it('counts allow and soft_deny rules', () => {
+    writeSettings({
+      autoMode: {
+        allow: ['Bash(npm test)', 'Read', 'Grep'],
+        soft_deny: ['Bash(git push )', 'Write(.env)'],
+        environment: ['local dev machine'],
+      },
+    });
+    expect(readProfileAutoMode(dir)).toEqual({ configured: true, allowCount: 3, softDenyCount: 2 });
+  });
+
+  it('treats an empty autoMode object as configured with zero rules', () => {
+    writeSettings({ autoMode: {} });
+    expect(readProfileAutoMode(dir)).toEqual({ configured: true, allowCount: 0, softDenyCount: 0 });
+  });
+
+  it('ignores non-array allow / soft_deny values', () => {
+    writeSettings({ autoMode: { allow: 'oops', soft_deny: 42 } });
+    expect(readProfileAutoMode(dir)).toEqual({ configured: true, allowCount: 0, softDenyCount: 0 });
+  });
+
+  it('recovers from malformed JSON', () => {
+    writeFileSync(join(dir, 'settings.json'), '{ not valid json');
+    expect(readProfileAutoMode(dir)).toEqual({ configured: false, allowCount: 0, softDenyCount: 0 });
+  });
+});

--- a/src/core/autoMode.ts
+++ b/src/core/autoMode.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface AutoModeStatus {
+  /** True when the profile's settings.json carries an `autoMode` object. */
+  configured: boolean;
+  /** Number of auto-approve `allow` patterns (0 when absent/non-array). */
+  allowCount: number;
+  /** Number of always-confirm `soft_deny` patterns (0 when absent/non-array). */
+  softDenyCount: number;
+}
+
+const NOT_CONFIGURED: AutoModeStatus = { configured: false, allowCount: 0, softDenyCount: 0 };
+
+function arrayLength(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+/**
+ * Read the auto-mode ("YOLO classifier") posture from a profile's
+ * `settings.json`. Read-only and defensive: a missing file, malformed JSON, or
+ * an `autoMode` that isn't an object all collapse to "not configured".
+ *
+ * We only surface the shape (configured + rule counts), never interpret the
+ * classifier semantics — so this stays stable across Claude Code releases that
+ * may rename or reshape the internal field.
+ */
+export function readProfileAutoMode(profilePath: string): AutoModeStatus {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(join(profilePath, 'settings.json'), 'utf-8'));
+  } catch {
+    return NOT_CONFIGURED;
+  }
+
+  if (!parsed || typeof parsed !== 'object') return NOT_CONFIGURED;
+  const autoMode = (parsed as { autoMode?: unknown }).autoMode;
+  if (!autoMode || typeof autoMode !== 'object' || Array.isArray(autoMode)) return NOT_CONFIGURED;
+
+  const block = autoMode as { allow?: unknown; soft_deny?: unknown };
+  return {
+    configured: true,
+    allowCount: arrayLength(block.allow),
+    softDenyCount: arrayLength(block.soft_deny),
+  };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -58,3 +58,6 @@ export {
 
 export { summarizeUsage, parseSinceDuration, totalTokens } from './usage.js';
 export type { ProfileUsageSummary, UsageOptions, UsageTotals } from './usage.js';
+
+export { readProfileAutoMode } from './autoMode.js';
+export type { AutoModeStatus } from './autoMode.js';


### PR DESCRIPTION
## What

Adds an **AUTOMODE** column to `aimux status` showing, per profile, whether an `autoMode` block exists in its `settings.json` and how many auto-approve `allow` rules it has.

```
NAME       AUTH           MODEL            AUTOMODE       SHARED
main       ✓ oauth        claude-opus-4-7  —              (source)
work       ✓ oauth        claude-opus-4-7  ✓ 8 allow      30/31
client     ✓ oauth        claude-opus-4-6  —              28/31
```

## Why

Profiles in aimux already map to different trust levels (personal / work / client / prod). Auto-mode is exactly the per-profile, per-trust-level knob — a `client-prod` profile wants a tight allow-list, a local sandbox can be loose. Surfacing it in the dashboard makes that posture visible at a glance, which fits the tool's whole isolation story.

## Design — deliberately read-only

`autoMode` is an **undocumented** Claude Code field (surfaced via a recent source-code write-up). To avoid coupling aimux to internals that Anthropic may rename or reshape between releases, this PR:

- only **reads** the user's `settings.json` and reports the *shape* (configured + rule counts),
- never interprets classifier semantics,
- collapses a missing file / malformed JSON / non-object `autoMode` to "not configured" (`—`).

So if the field changes upstream, the column just shows `—` — nothing breaks.

## Changes

- `src/core/autoMode.ts` — new `readProfileAutoMode(profilePath)` helper + `AutoModeStatus` type.
- `src/core/autoMode.test.ts` — 6 unit tests (missing file, no block, counts, empty object, non-array values, malformed JSON).
- `src/components/StatusView.tsx` — new column.
- exports + README command-table line.

## Tests

137 passing (131 + 6 new). Build clean.
