### PR TITLE
fix(deps): bump transitive ws to 8.21.0 (GHSA-58qx-3vcg-4xpx)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "aimux",
+  "name": "@digital-threads/aimux",
   "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aimux",
+      "name": "@digital-threads/aimux",
       "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
@@ -26,7 +26,7 @@
         "vitest": "^4.1.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@alcalzone/ansi-tokenize": {
@@ -2385,9 +2385,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {
-    "aimux": "./dist/cli.js"
+    "aimux": "dist/cli.js"
   },
   "scripts": {
     "dev": "tsx src/cli.tsx",


### PR DESCRIPTION
## What

Clears the open Dependabot alert (medium): `ws@8.20.0`, pulled in transitively through `ink@7.0.1`, was affected by an uninitialized-memory-disclosure advisory (GHSA-58qx-3vcg-4xpx, fixed in 8.20.1).

`npm update ws` resolves it to `8.21.0`. `npm audit` now reports 0 vulnerabilities.

The bump also normalised the `bin` path (`./dist/cli.js` → `dist/cli.js`), which silences the harmless publish warning npm was emitting.

## Scope

Lockfile-only dependency fix plus a one-line `package.json` bin normalisation. No source changes — the published package resolves `ws` through `ink`'s range anyway, so no republish is required; this just clears the alert on the repo.

## Testing

`vitest run` 154/154 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)