### PR TITLE
feat(core): реэкспорт active-profile хелперов из публичного barrel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.12.0] - 2026-06-08
+
+### Added
+- `core` barrel now re-exports `loadActiveProfile`, `saveActiveProfile`, and
+  `getActiveProfilePath` from `@digital-threads/aimux/core`. Additive — lets
+  external consumers read/switch the active profile through the public API
+  without deep-importing. No behavior change.
+
 ## [0.11.2] - 2026-06-08
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -70,3 +70,5 @@ export type { ModelPricing } from './pricing.js';
 
 export { unifyAllSessions, cachedUnifiedSessions, deriveName } from './unifiedSessions.js';
 export type { UnifiedSession } from './unifiedSessions.js';
+
+export { loadActiveProfile, saveActiveProfile, getActiveProfilePath } from './activeProfile.js';


### PR DESCRIPTION
## Что

`@digital-threads/aimux/core` теперь реэкспортит `loadActiveProfile`, `saveActiveProfile`, `getActiveProfilePath` из `activeProfile.ts`. Раньше они были только в сабмодуле и недоступны через публичный barrel (exports-карта отдаёт лишь `./core`).

## Зачем

Внешним потребителям (в т.ч. switch-active-profile в Loom) нужен публичный доступ к чтению/смене активного профиля без deep-import приватного модуля.

## Совместимость

Чисто аддитивно: только новые реэкспорты, поведение не меняется, ничего не удалено/переименовано. semver minor 0.11.2 → 0.12.0. `npm test` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)