### PR TITLE
fix(plugins): per-profile plugin metadata so marketplace refresh works under a profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [0.12.0] - 2026-06-08
+## [0.13.0] - 2026-06-11
+
+### Fixed
+- **Plugin marketplaces no longer fail validation under a profile.** Newer Claude
+  Code checks that each marketplace's `installLocation` is literally inside
+  `$CLAUDE_CONFIG_DIR/plugins/marketplaces` (string prefix, not realpath). Because
+  aimux symlinked the whole `plugins/` directory to the shared `~/.claude/plugins`,
+  the shared `known_marketplaces.json` carried `~/.claude/...` paths that don't match
+  a profile's config dir — so `/plugin` refresh/update reported
+  `corrupted installLocation` and showed stale versions. Plugins still loaded, but
+  could not be refreshed from within a profile.
+
+### Changed
+- **Per-profile plugin metadata.** A profile's `plugins/` is now a real directory:
+  content (`marketplaces/`, `cache/`, `data/`, …) is still symlinked to the shared
+  source so plugin bytes stay shared, but `known_marketplaces.json` and
+  `installed_plugins.json` are real, path-projected copies whose `installLocation`
+  values point inside the profile. The shared source (`~/.claude/plugins`) remains the
+  source of truth; the projection is regenerated on sync. A plugin installed from
+  within a profile is back-merged (additively) into the source so it propagates to the
+  other profiles. Conversion is automatic and lazy on the next `aimux run`, idempotent,
+  and never touches the source profile (`~/.claude`); an older aimux treats the new
+  layout as a local override and leaves it intact.
 
 ### Added
 - `core` barrel now re-exports `loadActiveProfile`, `saveActiveProfile`, and

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ All profile commands support **prefix matching**: `aimux run w` → `work`, `aim
       agents/ → ~/.claude/agents      ← symlink (shared)
       skills/ → ~/.claude/skills      ← symlink (shared)
       memory/ → ~/.claude/memory      ← symlink (shared)
+      plugins/                        ← real dir (shared content, per-profile metadata)
+        marketplaces/ → ~/.claude/plugins/marketplaces   ← symlink (shared)
+        cache/        → ~/.claude/plugins/cache           ← symlink (shared)
+        known_marketplaces.json       ← real file (paths point inside this profile)
+        installed_plugins.json        ← real file (paths point inside this profile)
       .credentials.json               ← real file (private)
       .claude.json                    ← real file (private)
     own/
@@ -154,6 +159,15 @@ All profile commands support **prefix matching**: `aimux run w` → `work`, `aim
 ```
 
 When you run `aimux run work`, it sets `CLAUDE_CONFIG_DIR=~/.aimux/profiles/work` and launches the CLI. Claude sees a complete config directory — shared content via symlinks, private auth locally.
+
+**Plugins** are shared too, but Claude validates that a marketplace's `installLocation`
+lives inside the active config directory. So each profile gets a real `plugins/`
+directory: the heavy content (`marketplaces/`, `cache/`) is symlinked to the shared
+`~/.claude/plugins`, while `known_marketplaces.json` and `installed_plugins.json` are
+real, path-rewritten copies. `~/.claude` stays the source of truth — install or update
+plugins from your main profile (or with `CLAUDE_CONFIG_DIR=~/.claude claude plugin …`)
+and every profile picks them up on its next run. A plugin installed from inside a
+profile is merged back into the shared source automatically.
 
 ## Per-profile environment variables
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/core/symlinks.test.ts
+++ b/src/core/symlinks.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, readlinkSync, symlinkSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import {
+  mkdirSync, rmSync, writeFileSync, readFileSync, readlinkSync, symlinkSync,
+  readdirSync, lstatSync, existsSync,
+} from 'node:fs';
+import { join, sep, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setAimuxDir } from './paths.js';
 import { createDefaultConfig, addProfile } from './config.js';
@@ -12,6 +15,7 @@ import {
   syncAllProfiles,
   checkProfileHealth,
   checkAllProfiles,
+  rewritePluginPaths,
 } from './symlinks.js';
 
 const TEST_DIR = join(tmpdir(), `aimux-symlink-test-${Date.now()}`);
@@ -236,5 +240,222 @@ describe('checkAllProfiles', () => {
     const reports = checkAllProfiles(config);
     expect(reports.size).toBe(2);
     expect(reports.get('work')!.valid).toContain('settings.json');
+  });
+});
+
+const SENTINEL = '.aimux-managed';
+
+function seedSharedPlugins() {
+  const pdir = join(SHARED_DIR, 'plugins');
+  mkdirSync(join(pdir, 'marketplaces', 'mk1'), { recursive: true });
+  writeFileSync(join(pdir, 'marketplaces', 'mk1', '.marker'), 'mk1');
+  mkdirSync(join(pdir, 'cache', 'mk1', 'p1'), { recursive: true });
+  mkdirSync(join(pdir, 'data'), { recursive: true });
+  const extDir = join(TEST_DIR, 'external-ext');
+  mkdirSync(extDir, { recursive: true });
+  writeFileSync(join(pdir, 'known_marketplaces.json'), JSON.stringify({
+    mk1: { installLocation: join(pdir, 'marketplaces', 'mk1'), source: { source: 'github', repo: 'a/b' } },
+    ext: { installLocation: extDir, source: { source: 'directory', path: extDir } },
+  }, null, 2));
+  writeFileSync(join(pdir, 'installed_plugins.json'), JSON.stringify({
+    version: 1,
+    plugins: { 'p1@mk1': [{ installLocation: join(pdir, 'cache', 'mk1', 'p1'), projectPath: join(TEST_DIR, 'someproject') }] },
+  }, null, 2));
+  return { pdir, extDir };
+}
+
+describe('rewritePluginPaths', () => {
+  const from = join('/src', 'plugins');
+  const to = join('/dst', 'plugins');
+
+  it('rewrites an exact prefix match', () => {
+    expect(rewritePluginPaths(from, from, to)).toBe(to);
+  });
+
+  it('rewrites a path under the prefix', () => {
+    expect(rewritePluginPaths(join(from, 'marketplaces', 'x'), from, to))
+      .toBe(join(to, 'marketplaces', 'x'));
+  });
+
+  it('leaves non-matching strings untouched', () => {
+    expect(rewritePluginPaths('/home/user/project', from, to)).toBe('/home/user/project');
+    // not a path-segment boundary -> must NOT match
+    expect(rewritePluginPaths('/src/pluginsX/y', from, to)).toBe('/src/pluginsX/y');
+  });
+
+  it('recurses objects/arrays and leaves non-strings', () => {
+    const input = { a: join(from, 'm'), b: [join(from, 'n'), 5, true, null], c: { d: '/other' } };
+    expect(rewritePluginPaths(input, from, to)).toEqual({
+      a: join(to, 'm'), b: [join(to, 'n'), 5, true, null], c: { d: '/other' },
+    });
+  });
+});
+
+describe('syncProfile plugins layout', () => {
+  it('builds a real plugins dir with symlinked content and projected json', () => {
+    seedShared(['settings.json']);
+    const { pdir, extDir } = seedSharedPlugins();
+    const config = makeConfig();
+    const result = syncProfile(config, 'work');
+
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    expect(lstatSync(ppdir).isSymbolicLink()).toBe(false);
+    expect(lstatSync(ppdir).isDirectory()).toBe(true);
+    expect(result.created).toContain('plugins');
+    expect(existsSync(join(ppdir, SENTINEL))).toBe(true);
+
+    expect(lstatSync(join(ppdir, 'marketplaces')).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(ppdir, 'marketplaces'))).toBe(join(pdir, 'marketplaces'));
+    expect(lstatSync(join(ppdir, 'cache')).isSymbolicLink()).toBe(true);
+
+    expect(lstatSync(join(ppdir, 'known_marketplaces.json')).isSymbolicLink()).toBe(false);
+    const km = JSON.parse(readFileSync(join(ppdir, 'known_marketplaces.json'), 'utf8'));
+    expect(km.mk1.installLocation).toBe(join(ppdir, 'marketplaces', 'mk1'));
+    expect(km.ext.installLocation).toBe(extDir);
+
+    const ip = JSON.parse(readFileSync(join(ppdir, 'installed_plugins.json'), 'utf8'));
+    expect(ip.plugins['p1@mk1'][0].installLocation).toBe(join(ppdir, 'cache', 'mk1', 'p1'));
+    expect(ip.plugins['p1@mk1'][0].projectPath).toBe(join(TEST_DIR, 'someproject'));
+
+    // projected installLocation satisfies claude's prefix check
+    const base = resolve(join(ppdir, 'marketplaces'));
+    const o = resolve(km.mk1.installLocation);
+    expect(o === base || o.startsWith(base + sep)).toBe(true);
+  });
+
+  it('is idempotent on re-sync', () => {
+    seedShared(['settings.json']);
+    seedSharedPlugins();
+    const config = makeConfig();
+    syncProfile(config, 'work');
+    const result2 = syncProfile(config, 'work');
+
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    expect(result2.conflicts).not.toContain('plugins');
+    expect(existsSync(join(ppdir, SENTINEL))).toBe(true);
+    const km = JSON.parse(readFileSync(join(ppdir, 'known_marketplaces.json'), 'utf8'));
+    expect(km.mk1.installLocation).toBe(join(ppdir, 'marketplaces', 'mk1'));
+  });
+
+  it('converts an old whole-dir plugins symlink to the new layout', () => {
+    seedShared(['settings.json']);
+    const { pdir } = seedSharedPlugins();
+    const config = makeConfig();
+    const workDir = join(PROFILES_DIR, 'work');
+    mkdirSync(workDir, { recursive: true });
+    symlinkSync(pdir, join(workDir, 'plugins'));
+
+    syncProfile(config, 'work');
+
+    const ppdir = join(workDir, 'plugins');
+    expect(lstatSync(ppdir).isSymbolicLink()).toBe(false);
+    expect(existsSync(join(ppdir, SENTINEL))).toBe(true);
+    expect(lstatSync(join(ppdir, 'marketplaces')).isSymbolicLink()).toBe(true);
+  });
+
+  it('back-merges a profile-local marketplace into source', () => {
+    seedShared(['settings.json']);
+    const { pdir } = seedSharedPlugins();
+    const config = makeConfig();
+    syncProfile(config, 'work');
+
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    const km = JSON.parse(readFileSync(join(ppdir, 'known_marketplaces.json'), 'utf8'));
+    km.localmk = { installLocation: join(ppdir, 'marketplaces', 'localmk'), source: { source: 'github', repo: 'c/d' } };
+    writeFileSync(join(ppdir, 'known_marketplaces.json'), JSON.stringify(km, null, 2));
+
+    syncProfile(config, 'work');
+
+    const srcKm = JSON.parse(readFileSync(join(pdir, 'known_marketplaces.json'), 'utf8'));
+    expect(srcKm.localmk).toBeDefined();
+    expect(srcKm.localmk.installLocation).toBe(join(pdir, 'marketplaces', 'localmk'));
+    expect(srcKm.mk1.installLocation).toBe(join(pdir, 'marketplaces', 'mk1'));
+
+    const km2 = JSON.parse(readFileSync(join(ppdir, 'known_marketplaces.json'), 'utf8'));
+    expect(km2.localmk.installLocation).toBe(join(ppdir, 'marketplaces', 'localmk'));
+  });
+
+  it('never overwrites an existing source key on back-merge (main wins)', () => {
+    seedShared(['settings.json']);
+    const { pdir } = seedSharedPlugins();
+    const config = makeConfig();
+    syncProfile(config, 'work');
+
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    const km = JSON.parse(readFileSync(join(ppdir, 'known_marketplaces.json'), 'utf8'));
+    km.mk1.source.repo = 'hacked/repo';
+    writeFileSync(join(ppdir, 'known_marketplaces.json'), JSON.stringify(km, null, 2));
+
+    syncProfile(config, 'work');
+
+    const srcKm = JSON.parse(readFileSync(join(pdir, 'known_marketplaces.json'), 'utf8'));
+    expect(srcKm.mk1.source.repo).toBe('a/b');
+  });
+
+  it('flags a user-owned plugins dir (no sentinel) as a conflict and leaves it', () => {
+    seedShared(['settings.json']);
+    seedSharedPlugins();
+    const config = makeConfig();
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    mkdirSync(ppdir, { recursive: true });
+    writeFileSync(join(ppdir, 'mine.txt'), 'user data');
+
+    const result = syncProfile(config, 'work');
+
+    expect(result.conflicts).toContain('plugins');
+    expect(existsSync(join(ppdir, 'mine.txt'))).toBe(true);
+    expect(existsSync(join(ppdir, SENTINEL))).toBe(false);
+  });
+
+  it('builds symlinks when source plugins has no json files', () => {
+    seedShared(['settings.json']);
+    mkdirSync(join(SHARED_DIR, 'plugins', 'marketplaces'), { recursive: true });
+    const config = makeConfig();
+
+    const result = syncProfile(config, 'work');
+
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    expect(result.created).toContain('plugins');
+    expect(lstatSync(join(ppdir, 'marketplaces')).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(ppdir, 'known_marketplaces.json'))).toBe(false);
+  });
+
+  it('prunes its own dangling symlinks but leaves a user symlink', () => {
+    seedShared(['settings.json']);
+    const { pdir } = seedSharedPlugins();
+    const config = makeConfig();
+    syncProfile(config, 'work');
+
+    const ppdir = join(PROFILES_DIR, 'work', 'plugins');
+    // an aimux-style link whose source entry no longer exists
+    symlinkSync(join(pdir, 'gone'), join(ppdir, 'gone'));
+    // a user's own link pointing outside the source (dangling)
+    symlinkSync(join(TEST_DIR, 'user-thing'), join(ppdir, 'user-link'));
+
+    syncProfile(config, 'work');
+
+    const entries = readdirSync(ppdir);
+    expect(entries).not.toContain('gone');
+    expect(entries).toContain('user-link');
+    expect(lstatSync(join(ppdir, 'user-link')).isSymbolicLink()).toBe(true);
+  });
+
+  it('does not build a plugins layout for the source profile', () => {
+    seedShared(['settings.json']);
+    seedSharedPlugins();
+    const config = makeConfig();
+    const result = syncProfile(config, 'main');
+    expect(result.created).not.toContain('plugins');
+  });
+
+  it('checkProfileHealth treats a managed plugins dir as valid', () => {
+    seedShared(['settings.json']);
+    seedSharedPlugins();
+    const config = makeConfig();
+    syncProfile(config, 'work');
+
+    const report = checkProfileHealth(config, 'work');
+    expect(report.valid).toContain('plugins');
+    expect(report.conflicts).not.toContain('plugins');
   });
 });

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -1,8 +1,10 @@
 import {
-  readdirSync, lstatSync, symlinkSync, readlinkSync,
+  readdirSync, lstatSync, statSync, symlinkSync, readlinkSync,
   existsSync, mkdirSync, unlinkSync,
+  readFileSync, writeFileSync, renameSync, openSync, closeSync,
 } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep, dirname } from 'node:path';
+import { randomBytes } from 'node:crypto';
 import type { AimuxConfig } from '../types/index.js';
 import { expandHome } from './paths.js';
 
@@ -22,6 +24,221 @@ export interface HealthReport {
   missing: string[];
   orphaned: string[];
   conflicts: string[];
+}
+
+const PLUGINS_DIRNAME = 'plugins';
+const PLUGINS_SENTINEL = '.aimux-managed';
+const PLUGINS_MERGE_LOCK = '.aimux-merge.lock';
+const PLUGIN_METADATA: { file: string; mergeKey: string }[] = [
+  { file: 'known_marketplaces.json', mergeKey: '' },
+  { file: 'installed_plugins.json', mergeKey: 'plugins' },
+];
+
+/**
+ * Rewrite any string under `fromPrefix` (path-segment boundary) to `toPrefix`,
+ * recursing through objects and arrays. Non-matching strings and non-strings are
+ * returned unchanged. Used to project plugin metadata between config dirs.
+ */
+export function rewritePluginPaths(value: unknown, fromPrefix: string, toPrefix: string): unknown {
+  if (typeof value === 'string') {
+    if (value === fromPrefix) return toPrefix;
+    if (value.startsWith(fromPrefix + sep)) return toPrefix + value.slice(fromPrefix.length);
+    return value;
+  }
+  if (Array.isArray(value)) return value.map((v) => rewritePluginPaths(v, fromPrefix, toPrefix));
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = rewritePluginPaths(v, fromPrefix, toPrefix);
+    }
+    return out;
+  }
+  return value;
+}
+
+function entryMap(data: unknown, mergeKey: string): Record<string, unknown> | undefined {
+  if (!data || typeof data !== 'object') return undefined;
+  const obj = data as Record<string, unknown>;
+  if (mergeKey === '') return obj;
+  const m = obj[mergeKey];
+  return m && typeof m === 'object' ? (m as Record<string, unknown>) : undefined;
+}
+
+function readJson(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return undefined;
+  }
+}
+
+let tmpCounter = 0;
+
+function writeJsonAtomic(path: string, data: unknown): void {
+  const tmp = `${path}.tmp-${process.pid}-${tmpCounter++}-${randomBytes(4).toString('hex')}`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, path);
+}
+
+/** Best-effort advisory lock; steals a stale (>30s) lock. Returns false if held. */
+function acquireLock(lockPath: string): boolean {
+  try {
+    closeSync(openSync(lockPath, 'wx'));
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    try {
+      if (Date.now() - statSync(lockPath).mtimeMs > 30_000) {
+        unlinkSync(lockPath);
+        closeSync(openSync(lockPath, 'wx'));
+        return true;
+      }
+    } catch {
+      // lost the race or cannot stat — treat as held
+    }
+    return false;
+  }
+}
+
+function releaseLock(lockPath: string): void {
+  try {
+    unlinkSync(lockPath);
+  } catch {
+    // already gone
+  }
+}
+
+/**
+ * Project one source metadata file into the profile with paths rewritten, after
+ * back-merging any profile-local entries (keys absent from source) into the source
+ * file. Additive only — existing source entries are never modified. Source writes
+ * are atomic and guarded by an advisory lock. No-ops if the source file is missing
+ * or unparseable.
+ */
+function projectPluginMetadata(
+  srcJson: string,
+  dstJson: string,
+  srcPlugins: string,
+  dstPlugins: string,
+  mergeKey: string,
+  lockPath: string,
+): void {
+  let srcData = readJson(srcJson);
+  if (srcData === undefined) return;
+
+  const dstData = existsSync(dstJson) ? readJson(dstJson) : undefined;
+  const srcMap = entryMap(srcData, mergeKey);
+  const dstMap = entryMap(dstData, mergeKey);
+
+  if (srcMap && dstMap) {
+    const additions: Record<string, unknown> = {};
+    for (const key of Object.keys(dstMap)) {
+      if (!(key in srcMap)) additions[key] = rewritePluginPaths(dstMap[key], dstPlugins, srcPlugins);
+    }
+    if (Object.keys(additions).length > 0 && acquireLock(lockPath)) {
+      try {
+        // Re-read the source under lock so we merge into the freshest copy. If it is
+        // missing or unparseable now (e.g. a concurrent writer mid-rename), abort the
+        // back-merge rather than overwrite the source with our stale snapshot.
+        const current = readJson(srcJson);
+        const currentMap = entryMap(current, mergeKey);
+        if (currentMap) {
+          let changed = false;
+          for (const [key, val] of Object.entries(additions)) {
+            if (!(key in currentMap)) {
+              currentMap[key] = val;
+              changed = true;
+            }
+          }
+          if (changed) writeJsonAtomic(srcJson, current);
+          srcData = current;
+        }
+      } finally {
+        releaseLock(lockPath);
+      }
+    }
+  }
+
+  writeJsonAtomic(dstJson, rewritePluginPaths(srcData, srcPlugins, dstPlugins));
+}
+
+/** Ensure `dst` is a symlink to `src`, repairing a wrong one and leaving real files. */
+function ensurePluginSymlink(src: string, dst: string): void {
+  if (lstatExists(dst)) {
+    const st = lstatSync(dst);
+    if (st.isSymbolicLink()) {
+      if (resolve(dirname(dst), readlinkSync(dst)) === resolve(src)) return;
+      unlinkSync(dst);
+    } else {
+      return; // a real file/dir we did not create — leave it
+    }
+  }
+  symlinkSync(src, dst);
+}
+
+/**
+ * Build/refresh the per-profile `plugins/` directory: a real dir whose content
+ * entries are symlinked to the shared source (bytes stay shared) while the two
+ * metadata files are real, path-projected copies. Idempotent; converts a legacy
+ * whole-dir symlink; reports a user-owned dir (no sentinel) as a conflict.
+ */
+function syncPluginsDir(sourcePluginsDir: string, profilePluginsDir: string, result: SyncResult): void {
+  if (lstatExists(profilePluginsDir)) {
+    const st = lstatSync(profilePluginsDir);
+    if (st.isSymbolicLink()) {
+      unlinkSync(profilePluginsDir); // legacy whole-dir symlink → rebuild
+    } else if (st.isDirectory()) {
+      if (!existsSync(join(profilePluginsDir, PLUGINS_SENTINEL))) {
+        result.conflicts.push(PLUGINS_DIRNAME);
+        return;
+      }
+      // managed → refresh below
+    } else {
+      result.conflicts.push(PLUGINS_DIRNAME);
+      return;
+    }
+  }
+
+  const isNew = !existsSync(profilePluginsDir);
+  mkdirSync(profilePluginsDir, { recursive: true });
+
+  const metaFiles = new Set(PLUGIN_METADATA.map((m) => m.file));
+
+  for (const entry of readdirSync(sourcePluginsDir)) {
+    if (metaFiles.has(entry)) continue;
+    ensurePluginSymlink(join(sourcePluginsDir, entry), join(profilePluginsDir, entry));
+  }
+
+  const srcPlugins = resolve(sourcePluginsDir);
+  const dstPlugins = resolve(profilePluginsDir);
+
+  // Prune only the symlinks we created — those pointing into the source plugins dir —
+  // whose source entry has since disappeared. A user's own symlink (pointing elsewhere)
+  // is left untouched even if dangling.
+  for (const entry of readdirSync(profilePluginsDir)) {
+    if (entry === PLUGINS_SENTINEL || metaFiles.has(entry)) continue;
+    const p = join(profilePluginsDir, entry);
+    if (!lstatSync(p).isSymbolicLink()) continue;
+    const target = resolve(dirname(p), readlinkSync(p));
+    if ((target === srcPlugins || target.startsWith(srcPlugins + sep)) && !existsSync(target)) {
+      unlinkSync(p);
+    }
+  }
+
+  const lockPath = join(sourcePluginsDir, PLUGINS_MERGE_LOCK);
+  for (const meta of PLUGIN_METADATA) {
+    projectPluginMetadata(
+      join(sourcePluginsDir, meta.file),
+      join(profilePluginsDir, meta.file),
+      srcPlugins,
+      dstPlugins,
+      meta.mergeKey,
+      lockPath,
+    );
+  }
+
+  writeFileSync(join(profilePluginsDir, PLUGINS_SENTINEL), '');
+  (isNew ? result.created : result.skipped).push(PLUGINS_DIRNAME);
 }
 
 export function getSharedElements(config: AimuxConfig): string[] {
@@ -83,6 +300,11 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
 
     if (privateSet.has(entry)) {
       result.private.push(entry);
+      continue;
+    }
+
+    if (entry === PLUGINS_DIRNAME && statSync(sourceTarget).isDirectory()) {
+      syncPluginsDir(sourceTarget, targetInProfile, result);
       continue;
     }
 
@@ -152,6 +374,20 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
     const targetInProfile = join(profilePath, entry);
     if (!lstatExists(targetInProfile)) {
       report.missing.push(entry);
+      continue;
+    }
+
+    if (entry === PLUGINS_DIRNAME) {
+      const st = lstatSync(targetInProfile);
+      if (st.isSymbolicLink()) {
+        // legacy whole-dir symlink — valid if it still points at the source
+        const linkTarget = resolve(profilePath, readlinkSync(targetInProfile));
+        report[linkTarget === join(sourcePath, entry) && existsSync(linkTarget) ? 'valid' : 'broken'].push(entry);
+      } else if (st.isDirectory() && existsSync(join(targetInProfile, PLUGINS_SENTINEL))) {
+        report.valid.push(entry); // aimux-managed per-profile plugins dir
+      } else {
+        report.conflicts.push(entry);
+      }
       continue;
     }
 


### PR DESCRIPTION
## Problem

Newer Claude Code validates that a marketplace's `installLocation` lives literally inside `\$CLAUDE_CONFIG_DIR/plugins/marketplaces` (string prefix via `resolve()`, not `realpath`). aimux symlinks the whole `plugins/` directory to the shared `~/.claude/plugins`, so the shared `known_marketplaces.json` carries `~/.claude/...` paths that never match a profile's config dir. Under a profile, `/plugin` refresh/update reports `corrupted installLocation` and shows stale versions. Plugins still load, but can't be refreshed from within a profile.

A single shared `known_marketplaces.json` can't hold paths valid for both `~/.claude` (main) and `~/.aimux/profiles/<name>` under this check.

## Change

A profile's `plugins/` becomes a real directory:

- content (`marketplaces/`, `cache/`, `data/`, …) stays **symlinked** to the shared source — plugin bytes are still shared;
- `known_marketplaces.json` and `installed_plugins.json` become **real**, path-projected copies whose `installLocation` points inside the profile.

`~/.claude/plugins` stays the source of truth; the projection is regenerated on `syncProfile`. A plugin installed from within a profile is **back-merged additively** into the source (atomic write under an advisory lock; existing source entries are never modified) so it propagates to the other profiles.

## Safety / backward compatibility

- Conversion is **automatic and lazy** on the next `aimux run` (cli already calls `syncProfile`), idempotent.
- The **source profile** (`~/.claude`, `is_source`) is never converted.
- **Downgrade-safe**: an older aimux sees the new real dir as a local override → conflict branch, leaves it intact; plugins still load.
- Back-merge aborts rather than overwrite if the source json is unparseable mid-write; prune only removes aimux's own dangling symlinks (a user symlink is left alone); source writes are atomic.
- `checkProfileHealth` recognises the managed dir as valid.

## Tests

`src/core/symlinks.test.ts` — `rewritePluginPaths` (prefix rewrite, recursion, leaves non-matching), layout build, idempotency, legacy-symlink conversion, back-merge into source, main-wins on key collision, user-owned-dir conflict, no-json source, source-profile untouched, prune safety, health check. Full suite: 182 passed.

## Verified live

On a real profile: `aimux rebuild work` converts the layout, source `known_marketplaces.json`/`installed_plugins.json` hashes unchanged, and `CLAUDE_CONFIG_DIR=~/.aimux/profiles/work claude plugin marketplace update caveman` — the exact command that failed before — now succeeds with no `corrupted installLocation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)