### PR TITLE
feat(core): headless run + per-session usage for Loom

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -44,8 +44,8 @@ export {
 
 export type { DetectedDir, InitResult } from './init.js';
 
-export { buildRunParams, launchProfile, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
-export type { RunOptions, RunParams } from './run.js';
+export { buildRunParams, launchProfile, runProfileHeadless, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
+export type { RunOptions, RunParams, HeadlessOptions, HeadlessResult } from './run.js';
 
 export {
   collectApiCredentials,
@@ -56,8 +56,8 @@ export {
   API_MODEL_DEFAULTS,
 } from './apiProfile.js';
 
-export { summarizeUsage, parseSinceDuration, totalTokens } from './usage.js';
-export type { ProfileUsageSummary, UsageOptions, UsageTotals } from './usage.js';
+export { summarizeUsage, usageBySession, parseSinceDuration, totalTokens } from './usage.js';
+export type { ProfileUsageSummary, SessionUsageSummary, UsageOptions, UsageTotals } from './usage.js';
 
 export { readProfileAutoMode } from './autoMode.js';
 export type { AutoModeStatus } from './autoMode.js';

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { buildRunParams, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
+import { buildRunParams, runProfileHeadless, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
 import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 
 function makeConfig(ownExtras?: Partial<ProfileConfig>): AimuxConfig {
@@ -225,5 +225,46 @@ describe('looksLikeSubcommand', () => {
   it('rejects undefined/empty', () => {
     expect(looksLikeSubcommand(undefined)).toBe(false);
     expect(looksLikeSubcommand('')).toBe(false);
+  });
+});
+
+describe('runProfileHeadless', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aimux-headless-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function stubConfig(): AimuxConfig {
+    return {
+      version: 1,
+      shared_source: dir,
+      profiles: { stub: { cli: 'node', path: dir } },
+      private: [],
+    };
+  }
+
+  it('captures stdout + exit code and injects task/workflow ids into env', async () => {
+    const script =
+      'process.stdout.write("OUT:" + process.env.LOOM_TASK_ID + ":" + process.env.LOOM_WORKFLOW_ID); process.exit(3);';
+    const res = await runProfileHeadless(stubConfig(), 'stub', {
+      extraArgs: ['-e', script],
+      taskId: 'tj-1',
+      workflowId: 'wf-1',
+    });
+    expect(res.exitCode).toBe(3);
+    expect(res.stdout).toBe('OUT:tj-1:wf-1');
+  });
+
+  it('captures stderr and leaves ids unset when not provided', async () => {
+    const script = 'process.stderr.write("ERR:" + String(process.env.LOOM_TASK_ID));';
+    const res = await runProfileHeadless(stubConfig(), 'stub', { extraArgs: ['-e', script] });
+    expect(res.exitCode).toBe(0);
+    expect(res.stderr).toBe('ERR:undefined');
+    expect(res.stdout).toBe('');
   });
 });

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -179,3 +179,74 @@ export function launchProfile(
     });
   });
 }
+
+export interface HeadlessOptions extends RunOptions {
+  /** Stamped into the spawned session env as LOOM_TASK_ID (spine link). */
+  taskId?: string;
+  /** Stamped into the spawned session env as LOOM_WORKFLOW_ID (spine link). */
+  workflowId?: string;
+  /** Working directory for the spawned process. */
+  cwd?: string;
+  /** Written to the child's stdin, then stdin is closed. */
+  input?: string;
+}
+
+export interface HeadlessResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Non-interactive launch: pipes stdio and captures stdout/stderr/exit instead of
+ * inheriting the terminal. `launchProfile` stays the interactive path, untouched.
+ *
+ * Injects LOOM_TASK_ID / LOOM_WORKFLOW_ID into the spawned session's env so that
+ * token-pilot and task-journal running inside it can tie their telemetry to the same
+ * task — the shared-ID "spine". CLI-agnostic: the caller supplies the print/prompt
+ * flags via `extraArgs` (e.g. `['-p', prompt]`), so this works for any AI CLI.
+ */
+export function runProfileHeadless(
+  config: AimuxConfig,
+  profileName: string,
+  options: HeadlessOptions = {},
+): Promise<HeadlessResult> {
+  const params = buildRunParams(config, profileName, options);
+  const env: NodeJS.ProcessEnv = { ...process.env, ...params.env };
+  if (options.taskId) env.LOOM_TASK_ID = options.taskId;
+  if (options.workflowId) env.LOOM_WORKFLOW_ID = options.workflowId;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(params.cli, params.args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+      cwd: options.cwd,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (err) => {
+      reject(new Error(`Failed to launch ${params.cli}: ${err.message}`));
+    });
+
+    if (options.input !== undefined) {
+      child.stdin?.write(options.input);
+    }
+    child.stdin?.end();
+
+    // 'close' fires after stdio streams are flushed, so captured output is complete.
+    child.on('close', (code, signal) => {
+      const exitCode = signal
+        ? 128 + (signal === 'SIGINT' ? 2 : signal === 'SIGTERM' ? 15 : 1)
+        : code ?? 1;
+      resolve({ exitCode, stdout, stderr });
+    });
+  });
+}

--- a/src/core/usage.test.ts
+++ b/src/core/usage.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import type { AimuxConfig } from '../types/index.js';
 import { getAimuxDir, setAimuxDir } from './paths.js';
-import { summarizeUsage, parseSinceDuration, totalTokens } from './usage.js';
+import { summarizeUsage, usageBySession, parseSinceDuration, totalTokens } from './usage.js';
 
 const TEST_DIR = join(tmpdir(), `aimux-usage-test-${Date.now()}`);
 const NOW_TS = '2026-05-14T00:00:00.000Z';
@@ -255,6 +255,44 @@ describe('summarizeUsage', () => {
     expect(summaries.map((s) => s.profile)).toEqual(['work']);
     expect(summaries[0].requests).toBe(1);
     expect(summaries[0].inputTokens).toBe(200);
+  });
+});
+
+describe('usageBySession', () => {
+  it('breaks usage down per session with profile and totals', () => {
+    writeProfileSessions('work', [
+      { sessionId: 'session-a', modified: 1000 },
+      { sessionId: 'session-b', modified: 2000 },
+    ]);
+    writeTranscript('-tmp-project', 'session-a', [
+      assistantLine('session-a', 'req-1', { input_tokens: 10, output_tokens: 5 }),
+    ]);
+    writeTranscript('-tmp-project', 'session-b', [
+      assistantLine('session-b', 'req-2', { input_tokens: 100, output_tokens: 50 }),
+    ]);
+
+    const rows = usageBySession(makeConfig());
+    const a = rows.find((r) => r.sessionId === 'session-a')!;
+    const b = rows.find((r) => r.sessionId === 'session-b')!;
+    expect(a.profile).toBe('work');
+    expect(a.requests).toBe(1);
+    expect(totalTokens(a)).toBe(15);
+    expect(totalTokens(b)).toBe(150);
+  });
+
+  it('deduplicates repeated lines and respects the profile filter', () => {
+    writeProfileSessions('work', [{ sessionId: 'session-a', modified: 1000 }]);
+    writeProfileSessions('main', [{ sessionId: 'session-m', modified: 1000 }]);
+    const repeated = assistantLine('session-a', 'req-1', { input_tokens: 10, output_tokens: 5 });
+    writeTranscript('-tmp-project', 'session-a', [repeated, repeated]);
+    writeTranscript('-tmp-main', 'session-m', [
+      assistantLine('session-m', 'req-2', { input_tokens: 7, output_tokens: 3 }),
+    ]);
+
+    const rows = usageBySession(makeConfig(), { profile: 'work' });
+    expect(rows.map((r) => r.sessionId)).toEqual(['session-a']);
+    expect(rows[0].requests).toBe(1);
+    expect(rows[0].inputTokens).toBe(10);
   });
 });
 

--- a/src/core/usage.ts
+++ b/src/core/usage.ts
@@ -22,6 +22,12 @@ export interface ProfileUsageSummary extends UsageTotals {
   models: Map<string, number>;
 }
 
+export interface SessionUsageSummary extends UsageTotals {
+  sessionId: string;
+  profile: string;
+  requests: number;
+}
+
 export interface UsageOptions {
   sinceMs?: number;
   profile?: string;
@@ -75,7 +81,7 @@ function numberValue(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
-function addUsage(summary: ProfileUsageSummary, usage: UsagePayload, model: string): void {
+function addUsage(summary: UsageTotals, usage: UsagePayload, model: string): void {
   const inputTokens = numberValue(usage.input_tokens);
   const cacheCreationInputTokens = numberValue(usage.cache_creation_input_tokens);
   const cacheReadInputTokens = numberValue(usage.cache_read_input_tokens);
@@ -137,28 +143,30 @@ export function parseSinceDuration(input: string, nowMs = Date.now()): number {
   return nowMs - amount * multiplier;
 }
 
-export function summarizeUsage(config: AimuxConfig, options: UsageOptions = {}): ProfileUsageSummary[] {
+interface UsageRecord {
+  profile: string;
+  sessionId: string;
+  model: string;
+  usage: UsagePayload;
+}
+
+// Single scan of all transcripts → deduplicated per-request usage records. Shared by
+// summarizeUsage (group by profile) and usageBySession (group by session) so both stay
+// in sync and the scan/dedup logic lives in one place.
+function collectUsageRecords(config: AimuxConfig, options: UsageOptions = {}): UsageRecord[] {
   const projectsRoot = join(expandHome(config.shared_source), 'projects');
-  const summaries = new Map<string, ProfileUsageSummary>();
-  const sessionSets = new Map<string, Set<string>>();
+  const records: UsageRecord[] = [];
+  if (!existsSync(projectsRoot)) return records;
+
   const seenRequests = new Set<string>();
   const history = loadSessionHistory();
   const profileMap = buildProfileSessionMap(config);
-
-  for (const profile of Object.keys(config.profiles)) {
-    summaries.set(profile, emptySummary(profile));
-    sessionSets.set(profile, new Set<string>());
-  }
-
-  if (!existsSync(projectsRoot)) {
-    return Array.from(summaries.values()).filter((s) => !options.profile || s.profile === options.profile);
-  }
 
   let cwdDirs: string[];
   try {
     cwdDirs = readdirSync(projectsRoot);
   } catch {
-    return Array.from(summaries.values()).filter((s) => !options.profile || s.profile === options.profile);
+    return records;
   }
 
   for (const cwdDir of cwdDirs) {
@@ -210,18 +218,33 @@ export function summarizeUsage(config: AimuxConfig, options: UsageOptions = {}):
         if (seenRequests.has(key)) continue;
         seenRequests.add(key);
 
-        if (!summaries.has(profile)) {
-          summaries.set(profile, emptySummary(profile));
-          sessionSets.set(profile, new Set<string>());
-        }
-        const summary = summaries.get(profile)!;
-        summary.requests += 1;
-        const model = formatModel(line.message?.model);
-        addUsage(summary, usage, model);
-        summary.models.set(model, (summary.models.get(model) ?? 0) + 1);
-        sessionSets.get(profile)!.add(sessionId);
+        records.push({ profile, sessionId, model: formatModel(line.message?.model), usage });
       }
     }
+  }
+
+  return records;
+}
+
+export function summarizeUsage(config: AimuxConfig, options: UsageOptions = {}): ProfileUsageSummary[] {
+  const summaries = new Map<string, ProfileUsageSummary>();
+  const sessionSets = new Map<string, Set<string>>();
+
+  for (const profile of Object.keys(config.profiles)) {
+    summaries.set(profile, emptySummary(profile));
+    sessionSets.set(profile, new Set<string>());
+  }
+
+  for (const rec of collectUsageRecords(config, options)) {
+    if (!summaries.has(rec.profile)) {
+      summaries.set(rec.profile, emptySummary(rec.profile));
+      sessionSets.set(rec.profile, new Set<string>());
+    }
+    const summary = summaries.get(rec.profile)!;
+    summary.requests += 1;
+    addUsage(summary, rec.usage, rec.model);
+    summary.models.set(rec.model, (summary.models.get(rec.model) ?? 0) + 1);
+    sessionSets.get(rec.profile)!.add(rec.sessionId);
   }
 
   for (const [profile, sessions] of sessionSets) {
@@ -234,10 +257,42 @@ export function summarizeUsage(config: AimuxConfig, options: UsageOptions = {}):
     .sort((a, b) => {
       if (a.profile === 'unknown') return 1;
       if (b.profile === 'unknown') return -1;
-      const totalA = a.inputTokens + a.cacheCreationInputTokens + a.cacheReadInputTokens + a.outputTokens;
-      const totalB = b.inputTokens + b.cacheCreationInputTokens + b.cacheReadInputTokens + b.outputTokens;
-      return totalB - totalA || a.profile.localeCompare(b.profile);
+      return totalTokens(b) - totalTokens(a) || a.profile.localeCompare(b.profile);
     });
+}
+
+function emptySessionSummary(sessionId: string, profile: string): SessionUsageSummary {
+  return {
+    sessionId,
+    profile,
+    requests: 0,
+    inputTokens: 0,
+    cacheCreationInputTokens: 0,
+    cacheReadInputTokens: 0,
+    outputTokens: 0,
+    estimatedCostUsd: 0,
+  };
+}
+
+// Per-session usage breakdown — same deduplicated transcript scan as summarizeUsage but
+// keyed by session_id, so Loom can attribute spend to a task once task↔session_id is
+// linked (the "spent" source for exact per-task cost).
+export function usageBySession(config: AimuxConfig, options: UsageOptions = {}): SessionUsageSummary[] {
+  const sessions = new Map<string, SessionUsageSummary>();
+
+  for (const rec of collectUsageRecords(config, options)) {
+    let summary = sessions.get(rec.sessionId);
+    if (!summary) {
+      summary = emptySessionSummary(rec.sessionId, rec.profile);
+      sessions.set(rec.sessionId, summary);
+    }
+    summary.requests += 1;
+    addUsage(summary, rec.usage, rec.model);
+  }
+
+  return Array.from(sessions.values()).sort(
+    (a, b) => totalTokens(b) - totalTokens(a) || a.sessionId.localeCompare(b.sessionId),
+  );
 }
 
 export function totalTokens(summary: UsageTotals): number {


### PR DESCRIPTION
## What
Two additive, backward-compatible core APIs so the Loom host can orchestrate aimux — standalone use is unchanged.

- **`runProfileHeadless()`** — non-interactive launch: pipes stdio, captures `stdout`/`stderr`/`exitCode`. The interactive `launchProfile` is untouched. Injects `LOOM_TASK_ID` / `LOOM_WORKFLOW_ID` into the spawned session env so token-pilot / task-journal telemetry ties to the same task (the shared-ID "spine"). CLI-agnostic — caller passes print/prompt flags via `extraArgs`.
- **`usageBySession()`** — per-session usage breakdown (the "spent" source for exact per-task cost). Internals refactored into a shared `collectUsageRecords` scanner; `summarizeUsage` output is unchanged.

## Backward compatibility
No existing behavior changes. New env vars only read in the new headless path; no env → identical behavior. `launchProfile` / `summarizeUsage` public output untouched.

## Verification
- `npx vitest run` → **186/186 pass** (added 4 tests)
- `npx tsc -p tsconfig.build.json --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)