### PR TITLE
feat: multi-CLI support (Codex) with cross-CLI handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **Multi-CLI support (Codex first).** A profile can now run a different AI CLI, not
+  just claude, selected by its `cli` field. `aimux profile add <name> --cli codex`
+  creates a Codex profile; `aimux auth login <name>` runs `codex login` under an
+  isolated `CODEX_HOME`; `aimux run <name>` launches Codex with the right model flag.
+  claude profiles are byte-for-byte unchanged — multi-CLI is strictly opt-in.
+  - **Per-CLI source-of-truth.** `shared_sources: { claude: ~/.claude, codex: ~/.codex }`
+    (additive; the legacy `shared_source` remains as the claude alias). Each CLI shares
+    from its own source.
+  - **Per-CLI share regimen.** claude keeps its denylist (everything except `private`).
+    Codex shares an allowlist of knowledge dirs (`skills`, `rules`, `memories`) and
+    keeps creds/state (`auth.json`, `config.toml`, `sessions/`, …) private. Codex
+    *plugin* sharing is a planned fast-follow.
+  - **Codex in `aimux agents`.** Codex sessions are discovered (from rollout files) and
+    listed alongside claude sessions with a CLI badge. Resuming routes per CLI
+    (`codex resume <id>` vs `claude --resume <id>`).
+- **Cross-CLI handoff.** `aimux handoff <sessionId> --to <profile>` continues a session
+  under a different CLI when you hit a subscription limit. Because the two CLIs'
+  transcripts are mutually unreadable, this is a summary handoff, not a native resume:
+  aimux reads the source transcript, summarizes it with the target profile (fully
+  self-contained — no external orchestration), then launches the target seeded with the
+  summary. The same-CLI path (claude↔claude, codex↔codex) still uses native resume.
+- **Public core API:** `adapterFor`/`CliAdapter`, `sourceFor`, `handoffSession`,
+  `buildHandoffPrompt`, and `UnifiedSession.cli`. Additive.
+
+### Notes
+- Cross-CLI handoff carries the *conversation context*, not the model — the target CLI
+  continues with a different model. The transfer is a summary, not a verbatim replay.
+
 ## [0.15.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.16.0] - 2026-06-20
 
 ### Added
 - **Multi-CLI support (Codex first).** A profile can now run a different AI CLI, not

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ aimux profile update w --unset-fallback-model   # remove it
 | `aimux agents` | Multi-profile agent view — see and manage claude background sessions across **all** profiles in one TUI |
 | `aimux profile add <name>` | Create new profile with symlinks |
 | `aimux profile add <name> --api` | Create a 3rd-party API profile (interactive endpoint + token prompt) |
+| `aimux profile add <name> --cli codex` | Create a profile for another AI CLI (e.g. Codex) |
+| `aimux handoff <sessionId> --to <profile>` | Continue a session under another profile/CLI via summary handoff |
 | `aimux profile update <name>` | Update model/cli settings |
 | `aimux profile update <name> --fallback-model <model>` | Set a fallback model, used when the primary is overloaded/unavailable |
 | `aimux profile update <name> --unset-fallback-model` | Remove the fallback model |
@@ -168,6 +170,52 @@ real, path-rewritten copies. `~/.claude` stays the source of truth — install o
 plugins from your main profile (or with `CLAUDE_CONFIG_DIR=~/.claude claude plugin …`)
 and every profile picks them up on its next run. A plugin installed from inside a
 profile is merged back into the shared source automatically.
+
+## Multiple AI CLIs (Codex)
+
+aimux isn't claude-only. A profile's `cli` field selects which AI CLI it runs, so you
+can keep claude **and** Codex subscriptions side by side — same shared brain, isolated
+auth — and even hand a live conversation from one to the other when a limit hits.
+
+```bash
+aimux profile add codework --cli codex   # a Codex profile
+aimux auth login codework                # runs `codex login` under an isolated CODEX_HOME
+aimux run codework                        # launches Codex with the right model flag
+aimux agents                              # claude + codex sessions in one view (CLI-badged)
+```
+
+- **Isolation per CLI.** Each CLI gets its own config-dir env (`CLAUDE_CONFIG_DIR` /
+  `CODEX_HOME`), so subscriptions never collide.
+- **Per-CLI source-of-truth.** `shared_sources` maps each CLI to its source
+  (`claude → ~/.claude`, `codex → ~/.codex`); the legacy `shared_source` stays as the
+  claude alias.
+- **Per-CLI sharing.** claude shares everything except `private`; Codex shares a
+  knowledge allowlist (`skills`, `rules`, `memories`) and keeps `auth.json` /
+  `config.toml` / `sessions/` private. (Codex plugin sharing is a planned follow-up.)
+- **claude is untouched.** Multi-CLI is strictly opt-in — without a non-claude profile
+  nothing changes.
+
+### Cross-CLI handoff (limit failover)
+
+Hit a subscription limit mid-session? Continue it under another CLI:
+
+```bash
+aimux handoff <sessionId> --to codework
+```
+
+The two CLIs' transcripts are mutually unreadable, so this is a **summary handoff**, not
+a native resume: aimux reads the source transcript, summarizes it with the target
+profile (self-contained — the target CLI does the summarizing), then launches the target
+seeded with that summary. Same-CLI continuation (claude↔claude, codex↔codex) still uses
+native resume (`aimux run <profile> --resume <id>`). Note: the *conversation context*
+carries over, not the model — the target continues with its own model.
+
+### Other models via an endpoint
+
+DeepSeek, local models (Ollama/LM Studio), and other Anthropic-compatible providers work
+today through an API profile (`aimux profile add <name> --api`, see below) by pointing
+`ANTHROPIC_BASE_URL` at the provider or a proxy. (Costs shown by `aimux usage` are
+estimated against claude pricing and will be off for other models.)
 
 ## Per-profile environment variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-threads/aimux",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   loadConfig, saveConfig, addProfile, removeProfile, expandHome,
-  ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs,
+  ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex,
   syncProfile, syncAllProfiles, checkAllProfiles,
   launchProfile, getLastProfile, recordHistory, getProfile,
   looksLikeSubcommand, adapterFor,
@@ -149,9 +149,17 @@ program
   .option('-s, --source <path>', 'Path to shared source directory (default: auto-detect)')
   .action((options: { source?: string }) => {
     try {
+      const codexHint = () => {
+        if (detectCodex()) {
+          console.log('\nCodex detected (~/.codex). Add a Codex profile with:');
+          console.log('  aimux profile add codework --cli codex');
+        }
+      };
+
       if (options.source) {
         const result = initFromSource(options.source);
         console.log(`✓ Initialized with source: ${result.source}`);
+        codexHint();
         return;
       }
 
@@ -174,6 +182,7 @@ program
         const copied = p.privatesCopied.length > 0 ? `, private: ${p.privatesCopied.join(', ')}` : '';
         console.log(`  ${p.name}: ${p.sync.created.length} symlinks created${copied}`);
       }
+      codexHint();
     } catch (err) {
       console.error(`Error: ${(err as Error).message}`);
       process.exit(1);

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -11,7 +11,7 @@ import {
   ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs,
   syncProfile, syncAllProfiles, checkAllProfiles,
   launchProfile, getLastProfile, recordHistory, getProfile,
-  looksLikeSubcommand,
+  looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
   loadProfileEnv, collectApiCredentials, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson,
 } from './core/index.js';
@@ -444,8 +444,9 @@ program
       .option('-m, --model <model>', 'Default model for this profile')
       .option('--fallback-model <model>', 'Fallback model when the primary is overloaded/unavailable')
       .option('--api', 'Configure a 3rd-party API endpoint instead of a Claude subscription')
+      .option('--cli <cli>', 'CLI for this profile (claude, codex, …)', 'claude')
       .description('Add a new profile')
-      .action(async (name: string, options: { auth: boolean; model?: string; fallbackModel?: string; api?: boolean }) => {
+      .action(async (name: string, options: { auth: boolean; model?: string; fallbackModel?: string; api?: boolean; cli?: string }) => {
         try {
           const config = requireConfig();
 
@@ -463,7 +464,7 @@ program
             apiVars = await collectApiCredentials();
           }
 
-          const updated = addProfile(config, name, { model: options.model, fallbackModel: options.fallbackModel });
+          const updated = addProfile(config, name, { cli: options.cli, model: options.model, fallbackModel: options.fallbackModel });
           saveConfig(updated);
           const profilePath = ensureProfileDir(updated, name);
           const sync = syncProfile(updated, name);
@@ -687,24 +688,23 @@ program
           const config = requireConfig();
           const resolved = resolveProfile(config, profile);
           const p = getProfile(config, resolved);
+          const adapter = adapterFor(p.cli);
           const profilePath = expandHome(p.path);
           const env: Record<string, string> = loadProfileEnv(p, profilePath);
-          if (!p.is_source) {
-            env.CLAUDE_CONFIG_DIR = profilePath;
-          }
+          Object.assign(env, adapter.configDirEnv(profilePath, p.is_source === true));
           const permWarning = checkDotenvPermissions(profilePath);
           if (permWarning) {
             console.error(`\x1b[33m⚠ ${permWarning}\x1b[0m`);
           }
           console.log(`Launching auth for profile '${resolved}'...`);
-          const result = spawnSync(p.cli, ['auth', 'login'], {
+          const result = spawnSync(p.cli, adapter.authArgs(), {
             stdio: 'inherit',
             env: { ...process.env, ...env },
           });
           if (result.error) {
             throw new Error(`Failed to launch ${p.cli}: ${result.error.message}`);
           }
-          const hasAuth = existsSync(join(profilePath, '.credentials.json'));
+          const hasAuth = existsSync(join(profilePath, adapter.credentialsFile()));
           if (hasAuth) {
             console.log(`✓ Profile '${resolved}' authenticated`);
           }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -388,7 +388,7 @@ program
 
       type PendingAction =
         | { type: 'exit' }
-        | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean };
+        | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean; cli: string };
 
       const { existsSync: existsSyncFn } = await import('node:fs');
 
@@ -413,6 +413,18 @@ program
             running = false;
             break;
           case 'attach': {
+            // Cross-CLI attach (e.g. a claude session under a codex profile) is NOT a
+            // native resume — the transcripts are mutually unreadable. That is the
+            // summary-handoff path (`aimux handoff`), shipped separately. Guard it here.
+            const targetCli = getProfile(config, action.profile).cli;
+            if (targetCli !== action.cli) {
+              console.error(
+                `Cannot resume a ${action.cli} session under a ${targetCli} profile — ` +
+                `cross-CLI continuation uses summary handoff (coming via 'aimux handoff'). ` +
+                `Attach via a ${action.cli} profile instead.`,
+              );
+              break;
+            }
             // Same as `aimux run <profile> --resume <id>`: resume the shared
             // transcript under the chosen profile. A live session needs
             // --fork-session (claude refuses to resume a running one otherwise).

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -652,6 +652,24 @@ program
   });
 
 program
+  .command('handoff <sessionId>')
+  .description('Continue a session under another profile/CLI via summary handoff')
+  .requiredOption('--to <profile>', 'Target profile to continue the session under')
+  .action(async (sessionId: string, options: { to: string }) => {
+    try {
+      const config = requireConfig();
+      const toProfile = resolveProfile(config, options.to);
+      const { handoffSession } = await import('./core/handoff.js');
+      console.log(`Summarizing session '${sessionId}' and handing off to '${toProfile}'…`);
+      const res = await handoffSession(config, sessionId, toProfile);
+      if (res.exitCode !== 0) console.error(`Handoff target exited with code ${res.exitCode}`);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+program
   .command('doctor')
   .description('Health check — find broken symlinks, missing shared entries, and local conflicts')
   .action(() => {

--- a/src/components/AgentsView.tsx
+++ b/src/components/AgentsView.tsx
@@ -14,7 +14,7 @@ import { summarizeUsage, totalTokens, type ProfileUsageSummary } from '../core/u
 
 export type AgentsAction =
   | { type: 'exit' }
-  | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean };
+  | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean; cli: string };
 
 interface Props {
   config: AimuxConfig;
@@ -555,6 +555,7 @@ export function AgentsView({ config, onAction }: Props) {
       profile,
       sessionId: currentSession.sessionId,
       cwd: currentSession.cwd,
+      cli: currentSession.cli,
       live:
         currentSession.isBackground &&
         currentSession.state !== 'done' &&
@@ -805,6 +806,7 @@ export function AgentsView({ config, onAction }: Props) {
               </Box>
               <Box width={50}>
                 {pinned.has(s.sessionId) && <Text color="yellow">★ </Text>}
+                {s.cli !== 'claude' && <Text color="magenta">{s.cli} </Text>}
                 <Text bold={isSel} color={isSel ? 'cyan' : undefined} wrap="truncate">{s.name}</Text>
               </Box>
               <Box width={22}>

--- a/src/core/adapters/adapters.test.ts
+++ b/src/core/adapters/adapters.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { adapterFor } from './index.js';
+
+describe('adapterFor', () => {
+  it('returns the claude adapter for cli "claude"', () => {
+    expect(adapterFor('claude').id).toBe('claude');
+  });
+
+  it('falls back to the claude adapter for unknown/custom cli (backward compat)', () => {
+    expect(adapterFor('/custom/claude-wrapper').id).toBe('claude');
+    expect(adapterFor('anything').id).toBe('claude');
+  });
+});
+
+describe('claudeAdapter run-path', () => {
+  it('emits --model when a model is set and not a subcommand', () => {
+    const a = adapterFor('claude');
+    expect(
+      a.modelArgs({ model: 'claude-opus-4-6', isSubcommand: false, userPassedModel: false, userPassedFallback: false }),
+    ).toEqual(['--model', 'claude-opus-4-6']);
+  });
+
+  it('omits --model when the user already passed one', () => {
+    const a = adapterFor('claude');
+    expect(
+      a.modelArgs({ model: 'claude-opus-4-6', isSubcommand: false, userPassedModel: true, userPassedFallback: false }),
+    ).toEqual([]);
+  });
+
+  it('omits --model for a subcommand invocation', () => {
+    const a = adapterFor('claude');
+    expect(
+      a.modelArgs({ model: 'claude-opus-4-6', isSubcommand: true, userPassedModel: false, userPassedFallback: false }),
+    ).toEqual([]);
+  });
+
+  it('appends --fallback-model when set and not already passed', () => {
+    const a = adapterFor('claude');
+    expect(
+      a.modelArgs({ model: 'm', fallbackModel: 'claude-sonnet-4-6', isSubcommand: false, userPassedModel: false, userPassedFallback: false }),
+    ).toEqual(['--model', 'm', '--fallback-model', 'claude-sonnet-4-6']);
+  });
+
+  it('sets CLAUDE_CONFIG_DIR for a non-source profile', () => {
+    const a = adapterFor('claude');
+    expect(a.configDirEnv('/home/u/.aimux/profiles/work', false)).toEqual({
+      CLAUDE_CONFIG_DIR: '/home/u/.aimux/profiles/work',
+    });
+  });
+
+  it('sets no config-dir env for the source profile', () => {
+    const a = adapterFor('claude');
+    expect(a.configDirEnv('/home/u/.claude', true)).toEqual({});
+  });
+});

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -1,0 +1,25 @@
+import { looksLikeSubcommand } from '../subcommand.js';
+import type { CliAdapter } from './types.js';
+
+export const claudeAdapter: CliAdapter = {
+  id: 'claude',
+
+  modelArgs({ model, fallbackModel, isSubcommand, userPassedModel, userPassedFallback }) {
+    const args: string[] = [];
+    if (model && !isSubcommand && !userPassedModel) {
+      args.push('--model', model);
+    }
+    if (fallbackModel && !isSubcommand && !userPassedFallback) {
+      args.push('--fallback-model', fallbackModel);
+    }
+    return args;
+  },
+
+  configDirEnv(profilePath, isSource): Record<string, string> {
+    return isSource ? {} : { CLAUDE_CONFIG_DIR: profilePath };
+  },
+
+  isSubcommand(firstArg) {
+    return looksLikeSubcommand(firstArg);
+  },
+};

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -44,4 +44,8 @@ export const claudeAdapter: CliAdapter = {
     if (opts?.fork) args.push('--fork-session');
     return args;
   },
+
+  headlessArgs(prompt) {
+    return ['-p', prompt];
+  },
 };

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -26,4 +26,16 @@ export const claudeAdapter: CliAdapter = {
   isShared(entry, configPrivate) {
     return !configPrivate.has(entry);
   },
+
+  authArgs() {
+    return ['auth', 'login'];
+  },
+
+  credentialsFile() {
+    return '.credentials.json';
+  },
+
+  defaultSource() {
+    return '~/.claude';
+  },
 };

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -38,4 +38,10 @@ export const claudeAdapter: CliAdapter = {
   defaultSource() {
     return '~/.claude';
   },
+
+  resumeArgs(sessionId, opts) {
+    const args = ['--resume', sessionId];
+    if (opts?.fork) args.push('--fork-session');
+    return args;
+  },
 };

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -22,4 +22,8 @@ export const claudeAdapter: CliAdapter = {
   isSubcommand(firstArg) {
     return looksLikeSubcommand(firstArg);
   },
+
+  isShared(entry, configPrivate) {
+    return !configPrivate.has(entry);
+  },
 };

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -48,4 +48,6 @@ export const claudeAdapter: CliAdapter = {
   headlessArgs(prompt) {
     return ['-p', prompt];
   },
+
+  headlessCaptureToFile: false,
 };

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -77,3 +77,18 @@ describe('resumeArgs', () => {
     expect(adapterFor('claude').resumeArgs('id-1', { fork: true })).toEqual(['--resume', 'id-1', '--fork-session']);
   });
 });
+
+describe('headlessArgs (summarizer capture)', () => {
+  it('claude prints to stdout via -p', () => {
+    const c = adapterFor('claude');
+    expect(c.headlessArgs('hi')).toEqual(['-p', 'hi']);
+    expect(c.headlessCaptureToFile).toBe(false);
+  });
+
+  it('codex writes the final message to outFile via exec --output-last-message', () => {
+    const a = adapterFor('codex');
+    expect(a.headlessCaptureToFile).toBe(true);
+    expect(a.headlessArgs('hi', '/tmp/out.txt')).toEqual(['exec', '--output-last-message', '/tmp/out.txt', 'hi']);
+    expect(a.headlessArgs('hi')).toEqual(['exec', 'hi']);
+  });
+});

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -65,3 +65,15 @@ describe('codexAdapter auth/source metadata', () => {
     expect(c.defaultSource()).toBe('~/.claude');
   });
 });
+
+describe('resumeArgs', () => {
+  it('codex resumes via "resume <id>" (no fork flag)', () => {
+    expect(adapterFor('codex').resumeArgs('uuid-1')).toEqual(['resume', 'uuid-1']);
+    expect(adapterFor('codex').resumeArgs('uuid-1', { fork: true })).toEqual(['resume', 'uuid-1']);
+  });
+
+  it('claude resumes via "--resume <id>" and adds --fork-session for a live session', () => {
+    expect(adapterFor('claude').resumeArgs('id-1')).toEqual(['--resume', 'id-1']);
+    expect(adapterFor('claude').resumeArgs('id-1', { fork: true })).toEqual(['--resume', 'id-1', '--fork-session']);
+  });
+});

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -46,3 +46,22 @@ describe('codexAdapter run-path', () => {
     expect(a.configDirEnv('/home/u/.codex', true)).toEqual({});
   });
 });
+
+describe('codexAdapter auth/source metadata', () => {
+  it('logs in via "codex login" and proves auth via auth.json', () => {
+    const a = adapterFor('codex');
+    expect(a.authArgs()).toEqual(['login']);
+    expect(a.credentialsFile()).toBe('auth.json');
+  });
+
+  it('defaults its source-of-truth to ~/.codex', () => {
+    expect(adapterFor('codex').defaultSource()).toBe('~/.codex');
+  });
+
+  it('claude keeps its auth/source metadata', () => {
+    const c = adapterFor('claude');
+    expect(c.authArgs()).toEqual(['auth', 'login']);
+    expect(c.credentialsFile()).toBe('.credentials.json');
+    expect(c.defaultSource()).toBe('~/.claude');
+  });
+});

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { adapterFor } from './index.js';
+
+describe('codexAdapter run-path', () => {
+  it('is selected for cli "codex"', () => {
+    expect(adapterFor('codex').id).toBe('codex');
+  });
+
+  it('emits -m <model> when set and not a subcommand', () => {
+    const a = adapterFor('codex');
+    expect(
+      a.modelArgs({ model: 'gpt-5-codex', isSubcommand: false, userPassedModel: false, userPassedFallback: false }),
+    ).toEqual(['-m', 'gpt-5-codex']);
+  });
+
+  it('omits the model flag for a subcommand (e.g. exec)', () => {
+    const a = adapterFor('codex');
+    expect(
+      a.modelArgs({ model: 'gpt-5-codex', isSubcommand: true, userPassedModel: false, userPassedFallback: false }),
+    ).toEqual([]);
+  });
+
+  it('omits the model flag when the user already passed one', () => {
+    const a = adapterFor('codex');
+    expect(
+      a.modelArgs({ model: 'gpt-5-codex', isSubcommand: false, userPassedModel: true, userPassedFallback: false }),
+    ).toEqual([]);
+  });
+
+  it('ignores fallbackModel (codex has no --fallback-model)', () => {
+    const a = adapterFor('codex');
+    expect(
+      a.modelArgs({ model: 'm', fallbackModel: 'other', isSubcommand: false, userPassedModel: false, userPassedFallback: false }),
+    ).toEqual(['-m', 'm']);
+  });
+
+  it('isolates via CODEX_HOME for a non-source profile', () => {
+    const a = adapterFor('codex');
+    expect(a.configDirEnv('/home/u/.aimux/profiles/codework', false)).toEqual({
+      CODEX_HOME: '/home/u/.aimux/profiles/codework',
+    });
+  });
+
+  it('sets no config-dir env for a source profile', () => {
+    const a = adapterFor('codex');
+    expect(a.configDirEnv('/home/u/.codex', true)).toEqual({});
+  });
+});

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -39,4 +39,9 @@ export const codexAdapter: CliAdapter = {
   defaultSource() {
     return '~/.codex';
   },
+
+  resumeArgs(sessionId) {
+    // codex resume <uuid>; codex has no fork-on-resume flag.
+    return ['resume', sessionId];
+  },
 };

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -1,0 +1,21 @@
+import { looksLikeSubcommand } from '../subcommand.js';
+import type { CliAdapter } from './types.js';
+
+export const codexAdapter: CliAdapter = {
+  id: 'codex',
+
+  modelArgs({ model, isSubcommand, userPassedModel }) {
+    // Codex takes the model via `-m`; it has no `--fallback-model`, so fallbackModel
+    // is intentionally ignored.
+    if (!model || isSubcommand || userPassedModel) return [];
+    return ['-m', model];
+  },
+
+  configDirEnv(profilePath, isSource): Record<string, string> {
+    return isSource ? {} : { CODEX_HOME: profilePath };
+  },
+
+  isSubcommand(firstArg) {
+    return looksLikeSubcommand(firstArg);
+  },
+};

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -27,4 +27,16 @@ export const codexAdapter: CliAdapter = {
   isShared(entry) {
     return CODEX_SHARED_DIRS.has(entry);
   },
+
+  authArgs() {
+    return ['login'];
+  },
+
+  credentialsFile() {
+    return 'auth.json';
+  },
+
+  defaultSource() {
+    return '~/.codex';
+  },
 };

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -1,6 +1,11 @@
 import { looksLikeSubcommand } from '../subcommand.js';
 import type { CliAdapter } from './types.js';
 
+// Codex keeps creds/state in many top-level files (auth.json, config.toml, sessions/,
+// sqlite DBs, …). Sharing is an ALLOWLIST of knowledge dirs, not a denylist — so new
+// codex state files are never accidentally shared. Plugins are added in a later PR.
+const CODEX_SHARED_DIRS = new Set(['skills', 'rules', 'memories']);
+
 export const codexAdapter: CliAdapter = {
   id: 'codex',
 
@@ -17,5 +22,9 @@ export const codexAdapter: CliAdapter = {
 
   isSubcommand(firstArg) {
     return looksLikeSubcommand(firstArg);
+  },
+
+  isShared(entry) {
+    return CODEX_SHARED_DIRS.has(entry);
   },
 };

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -44,4 +44,8 @@ export const codexAdapter: CliAdapter = {
     // codex resume <uuid>; codex has no fork-on-resume flag.
     return ['resume', sessionId];
   },
+
+  headlessArgs(prompt) {
+    return ['exec', prompt];
+  },
 };

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -45,7 +45,11 @@ export const codexAdapter: CliAdapter = {
     return ['resume', sessionId];
   },
 
-  headlessArgs(prompt) {
-    return ['exec', prompt];
+  headlessArgs(prompt, outFile) {
+    // codex exec stdout is noisy (header, token counts, echo). --output-last-message
+    // writes ONLY the final assistant message, so the summarizer reads a clean result.
+    return outFile ? ['exec', '--output-last-message', outFile, prompt] : ['exec', prompt];
   },
+
+  headlessCaptureToFile: true,
 };

--- a/src/core/adapters/index.ts
+++ b/src/core/adapters/index.ts
@@ -1,10 +1,12 @@
 import type { CliAdapter } from './types.js';
 import { claudeAdapter } from './claude.js';
+import { codexAdapter } from './codex.js';
 
 export type { CliAdapter } from './types.js';
 
 const REGISTRY: Record<string, CliAdapter> = {
   claude: claudeAdapter,
+  codex: codexAdapter,
 };
 
 /** Select the adapter for a profile's `cli`. Unknown/custom values fall back to the

--- a/src/core/adapters/index.ts
+++ b/src/core/adapters/index.ts
@@ -1,0 +1,14 @@
+import type { CliAdapter } from './types.js';
+import { claudeAdapter } from './claude.js';
+
+export type { CliAdapter } from './types.js';
+
+const REGISTRY: Record<string, CliAdapter> = {
+  claude: claudeAdapter,
+};
+
+/** Select the adapter for a profile's `cli`. Unknown/custom values fall back to the
+ *  claude adapter, preserving pre-multi-CLI behavior (every profile was claude-flavored). */
+export function adapterFor(cli: string): CliAdapter {
+  return REGISTRY[cli] ?? claudeAdapter;
+}

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -35,4 +35,8 @@ export interface CliAdapter {
   /** Default source-of-truth dir for this CLI, used when registering `shared_sources`
    *  for a freshly added non-claude profile (claude: `~/.claude`; codex: `~/.codex`). */
   defaultSource(): string;
+
+  /** Args to resume an existing session by id (claude: `--resume <id>` [+ `--fork-session`];
+   *  codex: `resume <id>`). */
+  resumeArgs(sessionId: string, opts?: { fork?: boolean }): string[];
 }

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -39,4 +39,8 @@ export interface CliAdapter {
   /** Args to resume an existing session by id (claude: `--resume <id>` [+ `--fork-session`];
    *  codex: `resume <id>`). */
   resumeArgs(sessionId: string, opts?: { fork?: boolean }): string[];
+
+  /** Args for a non-interactive one-shot with a prompt, captured via runProfileHeadless
+   *  (claude: `-p <prompt>`; codex: `exec <prompt>`). Used by the cross-CLI summarizer. */
+  headlessArgs(prompt: string): string[];
 }

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -18,4 +18,9 @@ export interface CliAdapter {
 
   /** Whether the first passthrough arg is a CLI subcommand (suppresses model flags). */
   isSubcommand(firstArg: string | undefined): boolean;
+
+  /** Whether a source-dir entry should be shared (symlinked) into profiles.
+   *  claude shares everything except the config's private set (denylist); other CLIs
+   *  may share only an allowlist of knowledge dirs. `configPrivate` is `config.private`. */
+  isShared(entry: string, configPrivate: Set<string>): boolean;
 }

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -23,4 +23,16 @@ export interface CliAdapter {
    *  claude shares everything except the config's private set (denylist); other CLIs
    *  may share only an allowlist of knowledge dirs. `configPrivate` is `config.private`. */
   isShared(entry: string, configPrivate: Set<string>): boolean;
+
+  /** Args to launch the CLI's interactive auth/login flow (claude: `auth login`;
+   *  codex: `login`). */
+  authArgs(): string[];
+
+  /** File inside the profile dir that proves the profile is authenticated
+   *  (claude: `.credentials.json`; codex: `auth.json`). */
+  credentialsFile(): string;
+
+  /** Default source-of-truth dir for this CLI, used when registering `shared_sources`
+   *  for a freshly added non-claude profile (claude: `~/.claude`; codex: `~/.codex`). */
+  defaultSource(): string;
 }

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -40,7 +40,13 @@ export interface CliAdapter {
    *  codex: `resume <id>`). */
   resumeArgs(sessionId: string, opts?: { fork?: boolean }): string[];
 
-  /** Args for a non-interactive one-shot with a prompt, captured via runProfileHeadless
-   *  (claude: `-p <prompt>`; codex: `exec <prompt>`). Used by the cross-CLI summarizer. */
-  headlessArgs(prompt: string): string[];
+  /** Args for a non-interactive one-shot with a prompt, captured via runProfileHeadless.
+   *  claude prints the answer to stdout (`-p <prompt>`); codex's stdout is noisy, so it
+   *  writes just the final message to `outFile` (`exec --output-last-message <f> <prompt>`).
+   *  Used by the cross-CLI summarizer. */
+  headlessArgs(prompt: string, outFile?: string): string[];
+
+  /** True when headless output must be read from `outFile` (codex) rather than stdout
+   *  (claude). The summarizer uses this to capture a clean result. */
+  headlessCaptureToFile: boolean;
 }

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -1,0 +1,21 @@
+/** Per-CLI driver. On PR1 it covers only the run-path (flags + config-dir env).
+ *  Sharing and session concerns are added in later PRs when a second CLI needs them. */
+export interface CliAdapter {
+  /** Stable identifier of the adapter family. */
+  id: string;
+
+  /** Build the model-selection args for a launch. Mirrors how the CLI takes a model. */
+  modelArgs(opts: {
+    model?: string;
+    fallbackModel?: string;
+    isSubcommand: boolean;
+    userPassedModel: boolean;
+    userPassedFallback: boolean;
+  }): string[];
+
+  /** Env that points the CLI at an isolated config dir. Empty for the source profile. */
+  configDirEnv(profilePath: string, isSource: boolean): Record<string, string>;
+
+  /** Whether the first passthrough arg is a CLI subcommand (suppresses model flags). */
+  isSubcommand(firstArg: string | undefined): boolean;
+}

--- a/src/core/addProfile.test.ts
+++ b/src/core/addProfile.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { addProfile } from './config.js';
+import type { AimuxConfig } from '../types/index.js';
+
+function base(): AimuxConfig {
+  return {
+    version: 1,
+    shared_source: '/home/u/.claude',
+    profiles: { main: { cli: 'claude', path: '/home/u/.claude', is_source: true } },
+    private: [],
+  };
+}
+
+describe('addProfile cli + shared_sources', () => {
+  it('creates a claude profile without touching shared_sources', () => {
+    const updated = addProfile(base(), 'work', {});
+    expect(updated.profiles.work.cli).toBe('claude');
+    expect(updated.shared_sources).toBeUndefined();
+  });
+
+  it('registers shared_sources for a codex profile (default ~/.codex)', () => {
+    const updated = addProfile(base(), 'codework', { cli: 'codex' });
+    expect(updated.profiles.codework.cli).toBe('codex');
+    expect(updated.shared_sources?.codex).toBe('~/.codex');
+  });
+
+  it('does not overwrite an existing per-CLI source', () => {
+    const cfg = { ...base(), shared_sources: { codex: '/custom/codex' } };
+    const updated = addProfile(cfg, 'codework', { cli: 'codex' });
+    expect(updated.shared_sources?.codex).toBe('/custom/codex');
+  });
+});

--- a/src/core/codexSessionScanner.test.ts
+++ b/src/core/codexSessionScanner.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { scanCodexInteractive } from './codexSessionScanner.js';
+
+const TEST_DIR = join(tmpdir(), `aimux-codex-scan-${Date.now()}`);
+const SRC = join(TEST_DIR, 'codex');
+
+function rollout(dir: string, file: string, records: unknown[]) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, file), records.map((r) => JSON.stringify(r)).join('\n') + '\n');
+}
+
+beforeEach(() => {
+  mkdirSync(SRC, { recursive: true });
+});
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('scanCodexInteractive', () => {
+  it('returns empty when there is no sessions dir', () => {
+    expect(scanCodexInteractive(SRC)).toEqual([]);
+  });
+
+  it('extracts sessionId, cwd, createdAt and the first user message as intent', () => {
+    rollout(join(SRC, 'sessions', '2026', '06', '18'), 'rollout-2026-06-18T14-05-17-019eda31-3172-7182-98a4-6c86e3c1ad6c.jsonl', [
+      { timestamp: '2026-06-18T10:05:23.926Z', type: 'session_meta', payload: { id: '019eda31-3172-7182-98a4-6c86e3c1ad6c', cwd: '/home/u/proj' } },
+      { timestamp: '2026-06-18T10:05:24.000Z', type: 'response_item', payload: { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'fix the auth bug' }] } },
+      { timestamp: '2026-06-18T10:05:25.000Z', type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'sure' }] } },
+    ]);
+
+    const out = scanCodexInteractive(SRC);
+    expect(out).toHaveLength(1);
+    expect(out[0].sessionId).toBe('019eda31-3172-7182-98a4-6c86e3c1ad6c');
+    expect(out[0].cwd).toBe('/home/u/proj');
+    expect(out[0].intent).toBe('fix the auth bug');
+    expect(out[0].events).toBe(2);
+    expect(out[0].createdAtMs).toBe(Date.parse('2026-06-18T10:05:23.926Z'));
+  });
+
+  it('falls back to the UUID in the filename when session_meta is missing an id', () => {
+    rollout(join(SRC, 'sessions', '2026', '06', '18'), 'rollout-2026-06-18T09-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl', [
+      { timestamp: '2026-06-18T09:00:00.000Z', type: 'session_meta', payload: { cwd: '/x' } },
+    ]);
+    const out = scanCodexInteractive(SRC);
+    expect(out).toHaveLength(1);
+    expect(out[0].sessionId).toBe('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  });
+
+  it('honors the scan window when a clock is provided', () => {
+    const day = 86_400_000;
+    const now = Date.parse('2026-06-18T12:00:00.000Z');
+    rollout(join(SRC, 'sessions', '2026', '06', '18'), 'rollout-2026-06-18T11-00-00-11111111-1111-1111-1111-111111111111.jsonl', [
+      { timestamp: '2026-06-18T11:00:00.000Z', type: 'session_meta', payload: { id: '11111111-1111-1111-1111-111111111111', cwd: '/y' } },
+    ]);
+    // windowDays=0.0001 → cutoff ~8.6s ago; the file's mtime is "now" so it stays in window.
+    const recent = scanCodexInteractive(SRC, { now, windowDays: 1 });
+    expect(recent).toHaveLength(1);
+    // A 100-day window cutoff in the FUTURE relative to mtime would exclude it.
+    const excluded = scanCodexInteractive(SRC, { now: now + 100 * day, windowDays: 1 });
+    expect(excluded).toHaveLength(0);
+  });
+});

--- a/src/core/codexSessionScanner.ts
+++ b/src/core/codexSessionScanner.ts
@@ -1,0 +1,137 @@
+import { readdirSync, readFileSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { expandHome } from './paths.js';
+import type { InteractiveSession } from './sessionScanner.js';
+
+// Codex stores each session as a JSONL "rollout" under
+// <source>/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl. Record shape is
+// { timestamp, type, payload } with types session_meta | turn_context |
+// response_item | event_msg (verified against codex-cli 0.139.0).
+
+interface ScanCodexOptions {
+  windowDays?: number;
+  /** Injectable clock for deterministic windowing in tests. */
+  now?: number;
+}
+
+function parseJson(line: string): any {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+/** Best-effort text extraction from a codex response_item content field, which is
+ *  either a string or an array of parts ({ text } / { type, text }). */
+function contentText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => (typeof part === 'string' ? part : typeof part?.text === 'string' ? part.text : ''))
+      .join('')
+      .trim();
+  }
+  return '';
+}
+
+function listRolloutFiles(sessionsRoot: string): string[] {
+  const out: string[] = [];
+  const stack = [sessionsRoot];
+  while (stack.length) {
+    const dir = stack.pop()!;
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      continue;
+    }
+    for (const name of entries) {
+      const p = join(dir, name);
+      let st;
+      try {
+        st = statSync(p);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) stack.push(p);
+      else if (name.startsWith('rollout-') && name.endsWith('.jsonl')) out.push(p);
+    }
+  }
+  return out;
+}
+
+/** Scan a codex source dir for interactive sessions, returning records compatible with
+ *  the claude `InteractiveSession` shape so `unifyAllSessions` can merge both. */
+export function scanCodexInteractive(sourceDir: string, opts: ScanCodexOptions = {}): InteractiveSession[] {
+  const sessionsRoot = join(expandHome(sourceDir), 'sessions');
+  if (!existsSync(sessionsRoot)) return [];
+
+  const windowDays = opts.windowDays ?? 7;
+  const now = opts.now ?? 0; // 0 => no windowing (tests pass explicit now)
+  const windowCutoff = now > 0 && Number.isFinite(windowDays) ? now - windowDays * 86_400_000 : -Infinity;
+
+  const sessions: InteractiveSession[] = [];
+
+  for (const filePath of listRolloutFiles(sessionsRoot)) {
+    let stat;
+    try {
+      stat = statSync(filePath);
+    } catch {
+      continue;
+    }
+    if (stat.mtimeMs < windowCutoff) continue;
+
+    let lines: string[];
+    try {
+      lines = readFileSync(filePath, 'utf-8').split('\n');
+    } catch {
+      continue;
+    }
+
+    let sessionId = '';
+    let cwd = '';
+    let createdAtMs = 0;
+    let intent = '';
+    let events = 0;
+
+    for (const raw of lines) {
+      if (!raw) continue;
+      const rec = parseJson(raw);
+      const payload = rec?.payload;
+      if (!rec || !payload) continue;
+
+      if (rec.type === 'session_meta') {
+        sessionId = payload.id ?? sessionId;
+        cwd = payload.cwd ?? cwd;
+        const t = Date.parse(rec.timestamp ?? payload.timestamp ?? '');
+        if (!Number.isNaN(t)) createdAtMs = t;
+      } else if (rec.type === 'response_item') {
+        events += 1;
+        if (!intent && payload.role === 'user') {
+          intent = contentText(payload.content);
+        }
+      }
+    }
+
+    if (!sessionId) {
+      const m = /rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/.exec(filePath);
+      if (m) sessionId = m[1];
+      else continue;
+    }
+
+    sessions.push({
+      sessionId,
+      cwd,
+      intent,
+      title: '',
+      cwdHashDir: '',
+      createdAtMs: createdAtMs || stat.birthtimeMs || stat.mtimeMs,
+      updatedAtMs: stat.mtimeMs,
+      events,
+    });
+  }
+
+  sessions.sort((a, b) => b.updatedAtMs - a.updatedAtMs);
+  return sessions;
+}

--- a/src/core/codexSharing.test.ts
+++ b/src/core/codexSharing.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, lstatSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { setAimuxDir } from './paths.js';
+import { syncProfile } from './symlinks.js';
+import type { AimuxConfig } from '../types/index.js';
+
+const TEST_DIR = join(tmpdir(), `aimux-codex-share-${Date.now()}`);
+const CODEX_SRC = join(TEST_DIR, 'codex-src');
+const CLAUDE_SRC = join(TEST_DIR, 'claude-src');
+const PROFILES = join(TEST_DIR, 'profiles');
+
+function config(): AimuxConfig {
+  return {
+    version: 1,
+    shared_source: CLAUDE_SRC,
+    shared_sources: { claude: CLAUDE_SRC, codex: CODEX_SRC },
+    profiles: {
+      main: { cli: 'claude', path: CLAUDE_SRC, is_source: true },
+      codework: { cli: 'codex', path: join(PROFILES, 'codework') },
+    },
+    private: ['.credentials.json', '.claude.json'],
+  };
+}
+
+beforeEach(() => {
+  // Codex source with a mix of knowledge dirs and private state.
+  for (const d of ['skills', 'rules', 'memories', 'sessions']) {
+    mkdirSync(join(CODEX_SRC, d), { recursive: true });
+  }
+  writeFileSync(join(CODEX_SRC, 'auth.json'), '{}');
+  writeFileSync(join(CODEX_SRC, 'config.toml'), 'model = "x"');
+  writeFileSync(join(CODEX_SRC, 'history.jsonl'), '');
+  mkdirSync(CLAUDE_SRC, { recursive: true });
+  mkdirSync(PROFILES, { recursive: true });
+  setAimuxDir(TEST_DIR);
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+describe('codex profile sharing (allowlist)', () => {
+  it('symlinks only knowledge dirs (skills/rules/memories) from the codex source', () => {
+    const profileDir = join(PROFILES, 'codework');
+    syncProfile(config(), 'codework');
+
+    for (const d of ['skills', 'rules', 'memories']) {
+      const p = join(profileDir, d);
+      expect(existsSync(p), `${d} should be linked`).toBe(true);
+      expect(lstatSync(p).isSymbolicLink(), `${d} should be a symlink`).toBe(true);
+    }
+  });
+
+  it('does NOT share codex creds/state (auth.json, config.toml, history.jsonl, sessions)', () => {
+    const profileDir = join(PROFILES, 'codework');
+    const result = syncProfile(config(), 'codework');
+
+    for (const f of ['auth.json', 'config.toml', 'history.jsonl', 'sessions']) {
+      expect(existsSync(join(profileDir, f)), `${f} must not be linked`).toBe(false);
+      expect(result.private, `${f} reported private`).toContain(f);
+    }
+  });
+});

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -98,6 +98,13 @@ export function getSourceProfile(config: AimuxConfig): [string, ProfileConfig] {
   return entry;
 }
 
+/** Resolve the source-of-truth dir for a CLI. Per-CLI `shared_sources` wins; absence
+ *  falls back to the legacy single `shared_source` (the claude source), preserving
+ *  pre-multi-CLI behavior. */
+export function sourceFor(config: AimuxConfig, cli: string): string {
+  return config.shared_sources?.[cli] ?? config.shared_source;
+}
+
 export function validateConfig(config: unknown): string[] {
   const errors: string[] = [];
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -3,6 +3,7 @@ import { parse, stringify } from 'yaml';
 import type { AimuxConfig, ProfileConfig, HistoryEntry } from '../types/index.js';
 import { DEFAULT_CONFIG, DEFAULT_PRIVATE_ELEMENTS } from '../types/index.js';
 import { getConfigPath, getHistoryPath, getAimuxDir, getProfilesDir, expandHome } from './paths.js';
+import { adapterFor } from './adapters/index.js';
 
 export function loadConfig(): AimuxConfig | null {
   const configPath = getConfigPath();
@@ -54,17 +55,23 @@ export function addProfile(
   if (config.profiles[name]) {
     throw new Error(`Profile '${name}' already exists`);
   }
+  const cli = options.cli ?? 'claude';
   const profilePath = `~/.aimux/profiles/${name}`;
   const updated = { ...config };
   updated.profiles = {
     ...config.profiles,
     [name]: {
-      cli: options.cli ?? 'claude',
+      cli,
       model: options.model,
       fallback_model: options.fallbackModel,
       path: profilePath,
     },
   };
+  // A non-claude CLI needs its own source-of-truth registered so sharing resolves to
+  // the right dir (not the legacy claude shared_source). Default to the adapter's source.
+  if (cli !== 'claude' && !config.shared_sources?.[cli]) {
+    updated.shared_sources = { ...config.shared_sources, [cli]: adapterFor(cli).defaultSource() };
+  }
   return updated;
 }
 

--- a/src/core/handoff.test.ts
+++ b/src/core/handoff.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildHandoffPrompt, buildSummarizePrompt, handoffSession, type HandoffDeps } from './handoff.js';
+import type { AimuxConfig } from '../types/index.js';
+import type { UnifiedSession } from './unifiedSessions.js';
+
+const config = { version: 1, shared_source: '/x', profiles: {}, private: [] } as AimuxConfig;
+
+function session(extra?: Partial<UnifiedSession>): UnifiedSession {
+  return {
+    sessionId: 'sess-1',
+    short: 'sess-1',
+    name: 'n',
+    intent: 'fix bug',
+    cli: 'claude',
+    cwd: '/p',
+    state: 'idle',
+    detail: '',
+    updatedAtMs: 1,
+    createdAtMs: 1,
+    events: 2,
+    isInteractive: true,
+    isBackground: false,
+    ...extra,
+  };
+}
+
+describe('prompt builders', () => {
+  it('buildHandoffPrompt embeds the summary and a continue instruction', () => {
+    const out = buildHandoffPrompt('  did X, next Y  ');
+    expect(out).toContain('did X, next Y');
+    expect(out).toContain('Continue from here');
+    expect(out).toContain('reached its usage limit');
+  });
+
+  it('buildSummarizePrompt embeds the transcript under a marker', () => {
+    const out = buildSummarizePrompt('TRANSCRIPT_BODY');
+    expect(out).toContain('--- TRANSCRIPT ---');
+    expect(out).toContain('TRANSCRIPT_BODY');
+    expect(out).toContain('immediate next step');
+  });
+});
+
+describe('handoffSession orchestration', () => {
+  it('summarizes the transcript with the target profile, then launches it seeded', async () => {
+    const summarize = vi.fn().mockResolvedValue('SUMMARY');
+    const launch = vi.fn().mockResolvedValue(0);
+    const deps: HandoffDeps = {
+      findSession: () => session({ cli: 'claude' }),
+      readTranscript: () => 'RAW',
+      summarize,
+      launch,
+    };
+
+    const res = await handoffSession(config, 'sess-1', 'codework', deps);
+
+    expect(summarize).toHaveBeenCalledWith(config, 'codework', buildSummarizePrompt('RAW'));
+    expect(launch).toHaveBeenCalledWith(config, 'codework', buildHandoffPrompt('SUMMARY'));
+    expect(res).toEqual({ sessionId: 'sess-1', fromCli: 'claude', toProfile: 'codework', summary: 'SUMMARY', exitCode: 0 });
+  });
+
+  it('falls back to the session intent when no transcript text is found', async () => {
+    const summarize = vi.fn().mockResolvedValue('S');
+    const deps: HandoffDeps = {
+      findSession: () => session({ intent: 'the goal' }),
+      readTranscript: () => '',
+      summarize,
+      launch: () => Promise.resolve(0),
+    };
+    await handoffSession(config, 'sess-1', 'codework', deps);
+    expect(summarize).toHaveBeenCalledWith(config, 'codework', buildSummarizePrompt('the goal'));
+  });
+
+  it('throws when the session is not found', async () => {
+    const deps: HandoffDeps = {
+      findSession: () => undefined,
+      readTranscript: () => '',
+      summarize: () => Promise.resolve('S'),
+      launch: () => Promise.resolve(0),
+    };
+    await expect(handoffSession(config, 'nope', 'codework', deps)).rejects.toThrow('not found');
+  });
+
+  it('throws when the summarizer returns nothing', async () => {
+    const deps: HandoffDeps = {
+      findSession: () => session(),
+      readTranscript: () => 'RAW',
+      summarize: () => Promise.resolve(''),
+      launch: () => Promise.resolve(0),
+    };
+    await expect(handoffSession(config, 'sess-1', 'codework', deps)).rejects.toThrow('no output');
+  });
+});

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -1,5 +1,7 @@
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, existsSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomBytes } from 'node:crypto';
 import type { AimuxConfig } from '../types/index.js';
 import { expandHome } from './paths.js';
 import { sourceFor, getProfile } from './config.js';
@@ -92,6 +94,20 @@ const defaultDeps: HandoffDeps = {
   readTranscript,
   async summarize(config, viaProfile, prompt) {
     const adapter = adapterFor(getProfile(config, viaProfile).cli);
+    if (adapter.headlessCaptureToFile) {
+      // codex: read the clean final message from a temp file (stdout is noisy).
+      const outFile = join(tmpdir(), `aimux-handoff-${process.pid}-${randomBytes(4).toString('hex')}.txt`);
+      try {
+        await runProfileHeadless(config, viaProfile, { extraArgs: adapter.headlessArgs(prompt, outFile) });
+        return existsSync(outFile) ? readFileSync(outFile, 'utf-8').trim() : '';
+      } finally {
+        try {
+          unlinkSync(outFile);
+        } catch {
+          /* best-effort cleanup */
+        }
+      }
+    }
     const res = await runProfileHeadless(config, viaProfile, { extraArgs: adapter.headlessArgs(prompt) });
     return res.stdout.trim();
   },

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -1,0 +1,135 @@
+import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { AimuxConfig } from '../types/index.js';
+import { expandHome } from './paths.js';
+import { sourceFor, getProfile } from './config.js';
+import { adapterFor } from './adapters/index.js';
+import { runProfileHeadless } from './run.js';
+import { launchProfile } from './run.js';
+import { unifyAllSessions, type UnifiedSession } from './unifiedSessions.js';
+
+/** Hard cap on transcript text fed to the summarizer, so a long session can't blow up
+ *  the summarizer's own context. Keeps the tail (most recent state matters most). */
+const TRANSCRIPT_CHAR_BUDGET = 60_000;
+
+/** Seed prompt handed to the TARGET CLI to continue a conversation from another CLI. */
+export function buildHandoffPrompt(summary: string): string {
+  return [
+    'You are continuing a conversation that took place in another AI assistant.',
+    'The previous session reached its usage limit and was handed off to you.',
+    'Here is a summary of what happened and where things stand:',
+    '',
+    summary.trim(),
+    '',
+    'Continue from here. Pick up the work as if it had been your own session.',
+  ].join('\n');
+}
+
+/** Prompt asking a CLI to compress a transcript into a continuation-ready summary. */
+export function buildSummarizePrompt(transcript: string): string {
+  return [
+    'Summarize the following AI coding session so it can be continued in a different assistant.',
+    'Capture: the goal, key decisions, the current state, files/commands involved, and the immediate next step.',
+    'Be concise but complete. Output only the summary, no preamble.',
+    '',
+    '--- TRANSCRIPT ---',
+    transcript,
+  ].join('\n');
+}
+
+function tail(text: string, budget: number): string {
+  return text.length <= budget ? text : text.slice(text.length - budget);
+}
+
+/** Best-effort raw transcript text for a session, per source CLI. Returns '' if the
+ *  transcript can't be located (caller falls back to the session intent). */
+export function readTranscript(config: AimuxConfig, session: UnifiedSession): string {
+  try {
+    if (session.cli === 'codex') {
+      const root = join(expandHome(sourceFor(config, 'codex')), 'sessions');
+      if (!existsSync(root)) return '';
+      const stack = [root];
+      while (stack.length) {
+        const dir = stack.pop()!;
+        for (const name of readdirSync(dir)) {
+          const p = join(dir, name);
+          const st = statSync(p);
+          if (st.isDirectory()) stack.push(p);
+          else if (name.includes(session.sessionId) && name.endsWith('.jsonl')) {
+            return tail(readFileSync(p, 'utf-8'), TRANSCRIPT_CHAR_BUDGET);
+          }
+        }
+      }
+      return '';
+    }
+    // claude: projects/<cwdHashDir>/<sessionId>.jsonl
+    if (!session.cwdHashDir) return '';
+    const path = join(
+      expandHome(sourceFor(config, 'claude')),
+      'projects',
+      session.cwdHashDir,
+      `${session.sessionId}.jsonl`,
+    );
+    if (!existsSync(path)) return '';
+    return tail(readFileSync(path, 'utf-8'), TRANSCRIPT_CHAR_BUDGET);
+  } catch {
+    return '';
+  }
+}
+
+export interface HandoffDeps {
+  findSession(config: AimuxConfig, sessionId: string): UnifiedSession | undefined;
+  readTranscript(config: AimuxConfig, session: UnifiedSession): string;
+  summarize(config: AimuxConfig, viaProfile: string, prompt: string): Promise<string>;
+  launch(config: AimuxConfig, toProfile: string, seedPrompt: string): Promise<number>;
+}
+
+const defaultDeps: HandoffDeps = {
+  findSession(config, sessionId) {
+    const all = unifyAllSessions(config, { windowDays: Infinity });
+    return all.find((s) => s.sessionId === sessionId || s.short === sessionId);
+  },
+  readTranscript,
+  async summarize(config, viaProfile, prompt) {
+    const adapter = adapterFor(getProfile(config, viaProfile).cli);
+    const res = await runProfileHeadless(config, viaProfile, { extraArgs: adapter.headlessArgs(prompt) });
+    return res.stdout.trim();
+  },
+  launch(config, toProfile, seedPrompt) {
+    return launchProfile(config, toProfile, { extraArgs: [seedPrompt] });
+  },
+};
+
+export interface HandoffResult {
+  sessionId: string;
+  fromCli: string;
+  toProfile: string;
+  summary: string;
+  exitCode: number;
+}
+
+/** Continue a session from one CLI under a profile of (possibly) another CLI, via a
+ *  summary handoff: read the source transcript, summarize it with the target profile,
+ *  then launch the target seeded with that summary. Self-contained — no external
+ *  orchestration. The summary is produced by the target CLI itself. */
+export async function handoffSession(
+  config: AimuxConfig,
+  sessionId: string,
+  toProfile: string,
+  deps: HandoffDeps = defaultDeps,
+): Promise<HandoffResult> {
+  const session = deps.findSession(config, sessionId);
+  if (!session) {
+    throw new Error(`Session '${sessionId}' not found`);
+  }
+  const transcript = deps.readTranscript(config, session) || session.intent || '';
+  if (!transcript) {
+    throw new Error(`No transcript content found for session '${sessionId}'`);
+  }
+  const summary = await deps.summarize(config, toProfile, buildSummarizePrompt(transcript));
+  if (!summary) {
+    throw new Error('Summarizer produced no output');
+  }
+  const exitCode = await deps.launch(config, toProfile, buildHandoffPrompt(summary));
+  return { sessionId: session.sessionId, fromCli: session.cli, toProfile, summary, exitCode };
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,6 +6,7 @@ export {
   removeProfile,
   getProfile,
   getSourceProfile,
+  sourceFor,
   validateConfig,
   loadHistory,
   saveHistory,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -76,4 +76,7 @@ export type { ModelPricing } from './pricing.js';
 export { unifyAllSessions, cachedUnifiedSessions, deriveName } from './unifiedSessions.js';
 export type { UnifiedSession } from './unifiedSessions.js';
 
+export { handoffSession, buildHandoffPrompt, buildSummarizePrompt, readTranscript } from './handoff.js';
+export type { HandoffDeps, HandoffResult } from './handoff.js';
+
 export { loadActiveProfile, saveActiveProfile, getActiveProfilePath } from './activeProfile.js';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -39,6 +39,7 @@ export type { SyncResult, HealthReport } from './symlinks.js';
 
 export {
   detectClaudeDirs,
+  detectCodex,
   initFromSource,
   initAutoDetect,
 } from './init.js';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -46,6 +46,8 @@ export type { DetectedDir, InitResult } from './init.js';
 
 export { buildRunParams, launchProfile, runProfileHeadless, looksLikeSubcommand, parseDotenv, loadProfileEnv } from './run.js';
 export type { RunOptions, RunParams, HeadlessOptions, HeadlessResult } from './run.js';
+export { adapterFor } from './adapters/index.js';
+export type { CliAdapter } from './adapters/index.js';
 export { openSession, buildSessionArgs } from './liveSession.js';
 export type { OpenSessionOptions, SessionEvent, TurnResult, LiveSession } from './liveSession.js';
 

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -70,6 +70,26 @@ export function detectClaudeDirs(): DetectedDir[] {
   return claudeDirs;
 }
 
+/** Detect a Codex source dir (~/.codex) by its config markers. Returns the path or null.
+ *  Used to pre-register `shared_sources.codex` at init so codex profiles resolve to it. */
+export function detectCodex(): string | null {
+  const codexPath = join(homedir(), '.codex');
+  if (!existsSync(codexPath)) return null;
+  try {
+    if (!lstatSync(codexPath).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  const CODEX_MARKERS = ['config.toml', 'auth.json', 'sessions', 'skills'];
+  let contents: string[];
+  try {
+    contents = readdirSync(codexPath);
+  } catch {
+    return null;
+  }
+  return contents.some((item) => CODEX_MARKERS.includes(item)) ? codexPath : null;
+}
+
 export function initFromSource(
   sourcePath: string,
   extraProfiles?: Array<{ name: string; existingPath?: string; model?: string }>,
@@ -97,6 +117,13 @@ export function initFromSource(
     },
     private: [...DEFAULT_PRIVATE_ELEMENTS],
   };
+
+  // Pre-register a detected Codex source so `aimux profile add <name> --cli codex`
+  // resolves sharing to ~/.codex. Profiles stay opt-in (created explicitly).
+  const codexSource = detectCodex();
+  if (codexSource) {
+    config.shared_sources = { claude: resolvedSource, codex: codexSource };
+  }
 
   const result: InitResult = {
     configCreated: true,

--- a/src/core/run.test.ts
+++ b/src/core/run.test.ts
@@ -268,3 +268,22 @@ describe('runProfileHeadless', () => {
     expect(res.stdout).toBe('');
   });
 });
+
+describe('buildRunParams — claude invariant (characterization)', () => {
+  it('produces the model flag and CLAUDE_CONFIG_DIR exactly as before', () => {
+    const p = buildRunParams(makeConfig(), 'work');
+    expect(p.cli).toBe('claude');
+    expect(p.args).toEqual(['--model', 'claude-opus-4-6']);
+    expect(p.env.CLAUDE_CONFIG_DIR).toBe('/home/user/.aimux/profiles/work');
+  });
+
+  it('suppresses the model flag for a subcommand and appends extraArgs', () => {
+    const p = buildRunParams(makeConfig(), 'work', { extraArgs: ['mcp', 'list'] });
+    expect(p.args).toEqual(['mcp', 'list']);
+  });
+
+  it('honors a user-passed --model over the profile default', () => {
+    const p = buildRunParams(makeConfig(), 'work', { extraArgs: ['--model', 'claude-sonnet-4-6'] });
+    expect(p.args).toEqual(['--model', 'claude-sonnet-4-6']);
+  });
+});

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 import { getProfile } from './config.js';
 import { expandHome } from './paths.js';
-import { looksLikeSubcommand } from './subcommand.js';
+import { adapterFor } from './adapters/index.js';
 
 export interface RunOptions {
   model?: string;
@@ -107,28 +107,27 @@ export function buildRunParams(
   const profile = getProfile(config, profileName);
   const profilePath = expandHome(profile.path);
   const model = options.model ?? profile.model;
+  const adapter = adapterFor(profile.cli);
 
   const extraArgs = options.extraArgs ?? [];
   const firstExtra = extraArgs[0];
-  const isSubcommand = looksLikeSubcommand(firstExtra);
+  const isSubcommand = adapter.isSubcommand(firstExtra);
   const userPassedModel = extraArgs.some((a) => a === '--model' || a === '-m');
   const userPassedFallback = extraArgs.some((a) => a === '--fallback-model');
 
-  const args: string[] = [];
-  if (model && !isSubcommand && !userPassedModel) {
-    args.push('--model', model);
-  }
-  if (profile.fallback_model && !isSubcommand && !userPassedFallback) {
-    args.push('--fallback-model', profile.fallback_model);
-  }
+  const args: string[] = adapter.modelArgs({
+    model,
+    fallbackModel: profile.fallback_model,
+    isSubcommand,
+    userPassedModel,
+    userPassedFallback,
+  });
   if (extraArgs.length > 0) {
     args.push(...extraArgs);
   }
 
   const env: Record<string, string> = loadProfileEnv(profile, profilePath);
-  if (!profile.is_source) {
-    env.CLAUDE_CONFIG_DIR = profilePath;
-  }
+  Object.assign(env, adapter.configDirEnv(profilePath, profile.is_source === true));
 
   return {
     cli: profile.cli,

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import type { AimuxConfig, ProfileConfig } from '../types/index.js';
 import { getProfile } from './config.js';
 import { expandHome } from './paths.js';
+import { looksLikeSubcommand } from './subcommand.js';
 
 export interface RunOptions {
   model?: string;
@@ -96,13 +97,7 @@ export interface RunParams {
   profilePath: string;
 }
 
-const SUBCOMMAND_TOKEN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
-
-export function looksLikeSubcommand(arg: string | undefined): boolean {
-  if (!arg) return false;
-  if (arg.startsWith('-')) return false;
-  return SUBCOMMAND_TOKEN.test(arg);
-}
+export { looksLikeSubcommand } from './subcommand.js';
 
 export function buildRunParams(
   config: AimuxConfig,

--- a/src/core/sessionActions.ts
+++ b/src/core/sessionActions.ts
@@ -2,14 +2,13 @@ import { spawn, spawnSync } from 'node:child_process';
 import type { AimuxConfig } from '../types/index.js';
 import { getProfile } from './config.js';
 import { expandHome } from './paths.js';
+import { adapterFor } from './adapters/index.js';
 
 function buildEnv(config: AimuxConfig, profileName: string): NodeJS.ProcessEnv {
   const profile = getProfile(config, profileName);
   const profilePath = expandHome(profile.path);
   const env: NodeJS.ProcessEnv = { ...process.env };
-  if (!profile.is_source) {
-    env.CLAUDE_CONFIG_DIR = profilePath;
-  }
+  Object.assign(env, adapterFor(profile.cli).configDirEnv(profilePath, profile.is_source === true));
   return env;
 }
 
@@ -127,8 +126,7 @@ export async function resumeSession(
   options: { cwd?: string; forkSession?: boolean } = {},
 ): Promise<number> {
   const profile = getProfile(config, profileName);
-  const args = ['--resume', sessionId];
-  if (options.forkSession) args.push('--fork-session');
+  const args = adapterFor(profile.cli).resumeArgs(sessionId, { fork: options.forkSession });
   await prepareTtyForHandoff();
   return new Promise((resolve, reject) => {
     const child = spawn(profile.cli, args, {

--- a/src/core/sourceFor.test.ts
+++ b/src/core/sourceFor.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { sourceFor } from './config.js';
+import type { AimuxConfig } from '../types/index.js';
+
+function cfg(extra?: Partial<AimuxConfig>): AimuxConfig {
+  return {
+    version: 1,
+    shared_source: '/home/u/.claude',
+    profiles: {},
+    private: [],
+    ...extra,
+  };
+}
+
+describe('sourceFor', () => {
+  it('falls back to legacy shared_source for claude when no shared_sources', () => {
+    expect(sourceFor(cfg(), 'claude')).toBe('/home/u/.claude');
+  });
+
+  it('falls back to legacy shared_source for any cli when no shared_sources', () => {
+    expect(sourceFor(cfg(), 'codex')).toBe('/home/u/.claude');
+  });
+
+  it('uses the per-CLI source when present', () => {
+    const config = cfg({ shared_sources: { claude: '/home/u/.claude', codex: '/home/u/.codex' } });
+    expect(sourceFor(config, 'claude')).toBe('/home/u/.claude');
+    expect(sourceFor(config, 'codex')).toBe('/home/u/.codex');
+  });
+
+  it('falls back to shared_source for a cli missing from shared_sources', () => {
+    const config = cfg({ shared_sources: { claude: '/home/u/.claude' } });
+    expect(sourceFor(config, 'codex')).toBe('/home/u/.claude');
+  });
+});

--- a/src/core/subcommand.ts
+++ b/src/core/subcommand.ts
@@ -1,0 +1,9 @@
+// Heuristic: a bare lowercase token (no leading dash) is a CLI subcommand
+// (e.g. `mcp`, `plugin`, `update`) rather than a prompt or flag value.
+const SUBCOMMAND_TOKEN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+export function looksLikeSubcommand(arg: string | undefined): boolean {
+  if (!arg) return false;
+  if (arg.startsWith('-')) return false;
+  return SUBCOMMAND_TOKEN.test(arg);
+}

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -7,6 +7,8 @@ import { join, resolve, sep, dirname } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import type { AimuxConfig } from '../types/index.js';
 import { expandHome } from './paths.js';
+import { sourceFor } from './config.js';
+import { adapterFor } from './adapters/index.js';
 
 export interface SyncResult {
   created: string[];
@@ -275,9 +277,10 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     };
   }
 
-  const sourcePath = expandHome(config.shared_source);
+  const adapter = adapterFor(profile.cli);
+  const sourcePath = expandHome(sourceFor(config, profile.cli));
   const profilePath = expandHome(profile.path);
-  const privateSet = new Set(config.private);
+  const configPrivate = new Set(config.private);
 
   if (!existsSync(profilePath)) {
     mkdirSync(profilePath, { recursive: true });
@@ -298,7 +301,7 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     const targetInProfile = join(profilePath, entry);
     const sourceTarget = join(sourcePath, entry);
 
-    if (privateSet.has(entry)) {
+    if (!adapter.isShared(entry, configPrivate)) {
       result.private.push(entry);
       continue;
     }
@@ -356,9 +359,10 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
 
   if (profile.is_source) return report;
 
-  const sourcePath = expandHome(config.shared_source);
+  const adapter = adapterFor(profile.cli);
+  const sourcePath = expandHome(sourceFor(config, profile.cli));
   const profilePath = expandHome(profile.path);
-  const privateSet = new Set(config.private);
+  const configPrivate = new Set(config.private);
 
   if (!existsSync(profilePath)) {
     report.missing.push('(profile directory)');
@@ -369,7 +373,7 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
   const profileEntries = readdirSync(profilePath);
 
   for (const entry of sourceEntries) {
-    if (privateSet.has(entry)) continue;
+    if (!adapter.isShared(entry, configPrivate)) continue;
 
     const targetInProfile = join(profilePath, entry);
     if (!lstatExists(targetInProfile)) {
@@ -406,7 +410,7 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
   }
 
   for (const entry of profileEntries) {
-    if (privateSet.has(entry)) continue;
+    if (!adapter.isShared(entry, configPrivate)) continue;
     if (!sourceEntries.has(entry)) {
       const stat = lstatSync(join(profilePath, entry));
       if (stat.isSymbolicLink()) {

--- a/src/core/unifiedSessions.ts
+++ b/src/core/unifiedSessions.ts
@@ -1,6 +1,8 @@
 import type { AimuxConfig } from '../types/index.js';
 import { listAllSessions, type SessionState } from './sessions.js';
 import { scanInteractiveSessions } from './sessionScanner.js';
+import { scanCodexInteractive } from './codexSessionScanner.js';
+import { sourceFor } from './config.js';
 import { loadSessionHistory, type SessionHistoryEntry } from './sessionHistory.js';
 import { buildProfileSessionMap } from './profileSessionMap.js';
 
@@ -9,6 +11,8 @@ export interface UnifiedSession {
   short: string;
   name: string;
   intent: string;
+  /** Which CLI produced this session (claude | codex | …). */
+  cli: string;
   cwd: string;
   cwdHashDir?: string;
   state: SessionState;
@@ -64,6 +68,7 @@ export function unifyAllSessions(
       short: shortId(s.sessionId),
       name: deriveName(s.intent, s.sessionId, s.title),
       intent: s.intent,
+      cli: 'claude',
       cwd: s.cwd,
       cwdHashDir: s.cwdHashDir,
       state: 'unknown',
@@ -75,6 +80,34 @@ export function unifyAllSessions(
       isInteractive: true,
       isBackground: false,
     });
+  }
+
+  // Seed codex interactive sessions from each codex source-of-truth. Tagged cli:'codex'
+  // so the agents view can label and route actions per CLI.
+  const codexClis = new Set(
+    Object.values(config.profiles).map((p) => p.cli).filter((c) => c === 'codex'),
+  );
+  for (const cli of codexClis) {
+    for (const s of scanCodexInteractive(sourceFor(config, cli), { windowDays: opts.windowDays, now: Date.now() })) {
+      if (bySessionId.has(s.sessionId)) continue;
+      bySessionId.set(s.sessionId, {
+        sessionId: s.sessionId,
+        short: shortId(s.sessionId),
+        name: deriveName(s.intent, s.sessionId, s.title),
+        intent: s.intent,
+        cli,
+        cwd: s.cwd,
+        cwdHashDir: s.cwdHashDir,
+        state: 'unknown',
+        detail: '',
+        updatedAtMs: s.updatedAtMs,
+        createdAtMs: s.createdAtMs,
+        events: s.events,
+        lastProfile: resolveLastProfile(s.sessionId),
+        isInteractive: true,
+        isBackground: false,
+      });
+    }
   }
 
   // Augment with background sessions from any profile's jobs/state.json.
@@ -99,6 +132,7 @@ export function unifyAllSessions(
           short: bg.short || shortId(bg.sessionId),
           name: bg.name,
           intent: bg.intent,
+          cli: config.profiles[profileName]?.cli ?? 'claude',
           cwd: bg.cwd,
           state: bg.state,
           detail: bg.detail,

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -11,7 +11,12 @@ export interface ProfileConfig {
 
 export interface AimuxConfig {
   version: number;
+  /** Legacy single source (the claude source-of-truth). Always present for backward
+   *  compatibility; equivalent to `shared_sources.claude`. */
   shared_source: string;
+  /** Per-CLI source-of-truth dirs, keyed by `cli` (e.g. `claude` → ~/.claude,
+   *  `codex` → ~/.codex). Additive; absence falls back to `shared_source`. */
+  shared_sources?: Record<string, string>;
   profiles: Record<string, ProfileConfig>;
   private: string[];
 }


### PR DESCRIPTION
## What

Multi-CLI support for aimux — run **Codex** alongside claude, with the same shared brain, isolated auth, and a cross-CLI handoff when a subscription limit hits. **claude behavior is byte-for-byte unchanged; multi-CLI is strictly opt-in.**

## How it's built (layered, each commit green)

- **`CliAdapter` foundation** — claude's flag/env logic extracted behind an adapter; `buildRunParams` routes through it. Pure refactor, invariant proven by the existing suite + characterization tests.
- **Codex adapter** — `-m` model flag, `CODEX_HOME` isolation, `codex login`, `codex resume`, `codex exec`.
- **Per-CLI source-of-truth** — `shared_sources: { claude: ~/.claude, codex: ~/.codex }` (additive; legacy `shared_source` is the claude alias) via `sourceFor`.
- **Per-CLI share regimen** — claude keeps its denylist; Codex shares a knowledge allowlist (`skills`/`rules`/`memories`) and keeps `auth.json`/`config.toml`/`sessions/` private.
- **Ergonomics** — `aimux profile add <name> --cli codex`; `auth login` routed per CLI under the right config dir.
- **`aimux agents` multi-CLI** — Codex sessions discovered from rollout files, listed with a CLI badge; resume routes per CLI; cross-CLI attach is guarded.
- **Cross-CLI handoff** — `aimux handoff <id> --to <profile>`: reads the source transcript, summarizes it with the target profile (self-contained — the target CLI does the summarizing, no external orchestration), then launches the target seeded with the summary. Same-CLI continuation still uses native resume.
- **Docs** — README + CHANGELOG.

## Backward compatibility

- `adapterFor` falls back to the claude adapter for any unknown/custom `cli`, so existing configs are unaffected.
- All new config (`shared_sources`) and public APIs (`adapterFor`/`CliAdapter`, `sourceFor`, `handoffSession`, `UnifiedSession.cli`) are additive.
- aimux stays self-contained — no Loom dependency.

## Out of scope (deliberate)

- **Codex plugin sharing** — fast-follow. Codex plugin metadata lives inline in `config.toml` (no install paths), so sharing needs a TOML merge / dependency decision; tracked separately.
- **Auto-failover** — handoff is manual only.
- Cross-CLI handoff carries conversation *context*, not the model (target continues with its own model); transfer is a summary, not a verbatim replay.

## Verification

- `npx vitest run` → **239/239 pass** (added codex adapter, sharing, scanner, handoff suites)
- `npx tsc -p tsconfig.build.json --noEmit` → clean

## Note on real-binary behavior

The handoff orchestration is dependency-injected and unit-tested; the live summarizer output quality (codex `exec` stdout shape) is best tuned against the real binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
