### PR TITLE
feat: codex full sharing parity + provider presets (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.17.0] - 2026-06-21
+
+### Added
+- **Codex profiles reach full parity with claude.** In addition to knowledge
+  (`skills`/`rules`/`memories`), codex profiles now also share:
+  - **Session transcripts** — `sessions/` + `session_index.jsonl`, the codex analogue of
+    claude's shared `projects/`. Switching codex subscriptions can `codex resume` the same
+    session under another profile.
+  - **Settings + plugins** — via codex's native config overlay: a symlinked
+    `aimux.config.toml` (→ source `config.toml`) layered with `-p aimux`, which codex reads
+    but never writes. The mutable `config.toml` itself stays private per profile. No TOML
+    dependency, no merge — pure symlink + flag (verified against codex-cli 0.139.0).
+- **Provider presets for Anthropic-compatible models.**
+  `aimux profile add <name> --provider <deepseek|kimi|glm|qwen|minimax|mimo>` fills the
+  provider's `ANTHROPIC_BASE_URL` + model mapping and prompts only for the token. These run
+  on the claude CLI (`cli: claude`), so they share the **full claude brain** (skills,
+  plugins, settings, memory, transcripts) and you can `--resume` a claude session under
+  them natively — switching the model mid-session, no summary needed.
+- `aimux init` detects `~/.codex` and pre-registers `shared_sources.codex`.
+
+### Fixed
+- **Codex auth shown correctly.** Profile list and `aimux auth status` checked claude's
+  `.credentials.json`, so codex profiles showed `✗ no auth` despite being logged in; now
+  routed through the adapter (`auth.json`).
+- **Codex session names in `aimux agents`** skip the injected context preamble
+  (`<environment_context>` / AGENTS.md) and show the real first prompt.
+
 ## [0.16.0] - 2026-06-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,12 +210,27 @@ seeded with that summary. Same-CLI continuation (claude↔claude, codex↔codex)
 native resume (`aimux run <profile> --resume <id>`). Note: the *conversation context*
 carries over, not the model — the target continues with its own model.
 
-### Other models via an endpoint
+### Other models via a provider preset
 
-DeepSeek, local models (Ollama/LM Studio), and other Anthropic-compatible providers work
-today through an API profile (`aimux profile add <name> --api`, see below) by pointing
-`ANTHROPIC_BASE_URL` at the provider or a proxy. (Costs shown by `aimux usage` are
-estimated against claude pricing and will be off for other models.)
+Many providers expose an **Anthropic-compatible** endpoint, so they run on the claude CLI
+itself — just a different base URL + token. A provider profile is therefore a **claude
+profile**: it shares the full claude brain (skills, plugins, settings, memory, transcripts)
+and you can even `--resume` a claude session under it natively (same CLI, same model swap).
+
+One command, prompts only for the token:
+
+```bash
+aimux profile add ds --provider deepseek   # fills base URL + model mapping
+aimux run ds
+```
+
+Built-in presets: **deepseek, kimi, glm, qwen, minimax, mimo**. Base URLs are verified;
+model names drift — update with `aimux profile update <name> -e ANTHROPIC_MODEL=…`.
+
+For anything else (local models via Ollama/LM Studio, a proxy, Bedrock/Vertex), use the
+generic `aimux profile add <name> --api` and point `ANTHROPIC_BASE_URL` at it (see below).
+Costs shown by `aimux usage` are estimated against claude pricing and will be off for
+non-claude models.
 
 ## Per-profile environment variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-threads/aimux",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -759,12 +759,16 @@ program
       .action(() => {
         try {
           const config = requireConfig();
-          const authFiles = ['.credentials.json', '.claude.json', 'policy-limits.json', 'mcp-needs-auth-cache.json', 'remote-settings.json'];
 
           for (const [name, profile] of Object.entries(config.profiles)) {
             const pPath = expandHome(profile.path);
             const tag = profile.is_source ? ' (source)' : '';
-            console.log(`${name}${tag}:`);
+            const credFile = adapterFor(profile.cli).credentialsFile();
+            // The credential file is the auth signal; claude has extra state files worth surfacing.
+            const authFiles = profile.cli === 'claude'
+              ? [credFile, '.claude.json', 'policy-limits.json', 'mcp-needs-auth-cache.json', 'remote-settings.json']
+              : [credFile];
+            console.log(`${name} [${profile.cli}]${tag}:`);
             for (const file of authFiles) {
               const exists = existsSync(join(pPath, file));
               console.log(`  ${exists ? '✓' : '✗'} ${file}`);

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -13,7 +13,7 @@ import {
   launchProfile, getLastProfile, recordHistory, getProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
-  loadProfileEnv, collectApiCredentials, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson,
+  loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson,
 } from './core/index.js';
 
 function collectRepeatable(value: string, previous: string[]): string[] {
@@ -465,9 +465,10 @@ program
       .option('-m, --model <model>', 'Default model for this profile')
       .option('--fallback-model <model>', 'Fallback model when the primary is overloaded/unavailable')
       .option('--api', 'Configure a 3rd-party API endpoint instead of a Claude subscription')
+      .option('--provider <name>', 'Anthropic-compatible provider preset (deepseek, kimi, glm, qwen, minimax, mimo)')
       .option('--cli <cli>', 'CLI for this profile (claude, codex, …)', 'claude')
       .description('Add a new profile')
-      .action(async (name: string, options: { auth: boolean; model?: string; fallbackModel?: string; api?: boolean; cli?: string }) => {
+      .action(async (name: string, options: { auth: boolean; model?: string; fallbackModel?: string; api?: boolean; provider?: string; cli?: string }) => {
         try {
           const config = requireConfig();
 
@@ -480,7 +481,16 @@ program
           // Collect credentials BEFORE mutating config/disk so a Ctrl+C
           // mid-prompt leaves no half-created profile behind.
           let apiVars: Record<string, string> | undefined;
-          if (options.api) {
+          if (options.provider) {
+            const preset = PROVIDER_PRESETS[options.provider.toLowerCase()];
+            if (!preset) {
+              throw new Error(
+                `Unknown provider '${options.provider}'. Available: ${Object.keys(PROVIDER_PRESETS).join(', ')}`,
+              );
+            }
+            console.log(`Configure ${preset.label} (${preset.baseUrl}) — enter your API token:`);
+            apiVars = await collectProviderCredentials(preset);
+          } else if (options.api) {
             console.log('Configure API endpoint (leave blank to use default):');
             apiVars = await collectApiCredentials();
           }

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -482,6 +482,11 @@ program
           // mid-prompt leaves no half-created profile behind.
           let apiVars: Record<string, string> | undefined;
           if (options.provider) {
+            // Provider presets are Anthropic-compatible endpoints — they run on the claude
+            // CLI. A non-claude --cli would ignore the ANTHROPIC_* env entirely.
+            if ((options.cli ?? 'claude') !== 'claude') {
+              throw new Error(`--provider works only with the claude CLI, not --cli ${options.cli}`);
+            }
             const preset = PROVIDER_PRESETS[options.provider.toLowerCase()];
             if (!preset) {
               throw new Error(

--- a/src/components/StatusView.tsx
+++ b/src/components/StatusView.tsx
@@ -41,6 +41,12 @@ function checkAuth(profile: ProfileConfig): AuthStatus {
     return { kind: 'oauth', active: true };
   }
 
+  // The OAuth-status probe is claude-specific (`claude auth status` JSON, CLAUDE_CONFIG_DIR).
+  // For other CLIs the credential-file check above is the verdict — no doomed subprocess.
+  if (profile.cli !== 'claude') {
+    return { kind: 'none' };
+  }
+
   const probeEnv: Record<string, string> = {};
   if (!profile.is_source) {
     probeEnv.CLAUDE_CONFIG_DIR = profilePath;

--- a/src/components/StatusView.tsx
+++ b/src/components/StatusView.tsx
@@ -8,6 +8,7 @@ import { expandHome } from '../core/paths.js';
 import { loadProfileEnv } from '../core/run.js';
 import { readProfileAutoMode } from '../core/autoMode.js';
 import { getSharedElements, checkAllProfiles } from '../core/symlinks.js';
+import { adapterFor } from '../core/adapters/index.js';
 
 interface Props {
   config: AimuxConfig;
@@ -36,7 +37,7 @@ function checkAuth(profile: ProfileConfig): AuthStatus {
     }
   }
 
-  if (existsSync(join(profilePath, '.credentials.json'))) {
+  if (existsSync(join(profilePath, adapterFor(profile.cli).credentialsFile()))) {
     return { kind: 'oauth', active: true };
   }
 

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -50,4 +50,12 @@ export const claudeAdapter: CliAdapter = {
   },
 
   headlessCaptureToFile: false,
+
+  globalArgs() {
+    return [];
+  },
+
+  extraLinks() {
+    return [];
+  },
 };

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -67,9 +67,12 @@ describe('codexAdapter auth/source metadata', () => {
 });
 
 describe('resumeArgs', () => {
-  it('codex resumes via "-p aimux resume <id>" (overlay; no fork flag)', () => {
-    expect(adapterFor('codex').resumeArgs('uuid-1')).toEqual(['-p', 'aimux', 'resume', 'uuid-1']);
-    expect(adapterFor('codex').resumeArgs('uuid-1', { fork: true })).toEqual(['-p', 'aimux', 'resume', 'uuid-1']);
+  it('codex resumes via "resume <id>" (overlay added by globalArgs; no fork flag)', () => {
+    // resumeArgs no longer hardcodes -p; the single injection point is globalArgs(),
+    // which resumeSession prepends. globalArgs('resume') === ['-p','aimux'].
+    expect(adapterFor('codex').resumeArgs('uuid-1')).toEqual(['resume', 'uuid-1']);
+    expect(adapterFor('codex').resumeArgs('uuid-1', { fork: true })).toEqual(['resume', 'uuid-1']);
+    expect(adapterFor('codex').globalArgs('resume')).toEqual(['-p', 'aimux']);
   });
 
   it('claude resumes via "--resume <id>" and adds --fork-session for a live session', () => {

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -85,11 +85,17 @@ describe('headlessArgs (summarizer capture)', () => {
     expect(c.headlessCaptureToFile).toBe(false);
   });
 
-  it('codex writes the final message to outFile via exec --output-last-message (with overlay)', () => {
+  it('codex writes the final message to outFile via exec --output-last-message (overlay added by buildRunParams)', () => {
     const a = adapterFor('codex');
     expect(a.headlessCaptureToFile).toBe(true);
-    expect(a.headlessArgs('hi', '/tmp/out.txt')).toEqual(['-p', 'aimux', 'exec', '--output-last-message', '/tmp/out.txt', 'hi']);
-    expect(a.headlessArgs('hi')).toEqual(['-p', 'aimux', 'exec', 'hi']);
+    // No -p here: headlessArgs flows through buildRunParams, whose globalArgs('exec')
+    // injects `-p aimux`. Including it here would double it.
+    expect(a.headlessArgs('hi', '/tmp/out.txt')).toEqual(['exec', '--output-last-message', '/tmp/out.txt', 'hi']);
+    expect(a.headlessArgs('hi')).toEqual(['exec', 'hi']);
+  });
+
+  it('globalArgs injects the overlay for exec so the headless summarizer carries it once', () => {
+    expect(adapterFor('codex').globalArgs('exec')).toEqual(['-p', 'aimux']);
   });
 });
 

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -67,9 +67,9 @@ describe('codexAdapter auth/source metadata', () => {
 });
 
 describe('resumeArgs', () => {
-  it('codex resumes via "resume <id>" (no fork flag)', () => {
-    expect(adapterFor('codex').resumeArgs('uuid-1')).toEqual(['resume', 'uuid-1']);
-    expect(adapterFor('codex').resumeArgs('uuid-1', { fork: true })).toEqual(['resume', 'uuid-1']);
+  it('codex resumes via "-p aimux resume <id>" (overlay; no fork flag)', () => {
+    expect(adapterFor('codex').resumeArgs('uuid-1')).toEqual(['-p', 'aimux', 'resume', 'uuid-1']);
+    expect(adapterFor('codex').resumeArgs('uuid-1', { fork: true })).toEqual(['-p', 'aimux', 'resume', 'uuid-1']);
   });
 
   it('claude resumes via "--resume <id>" and adds --fork-session for a live session', () => {
@@ -85,10 +85,40 @@ describe('headlessArgs (summarizer capture)', () => {
     expect(c.headlessCaptureToFile).toBe(false);
   });
 
-  it('codex writes the final message to outFile via exec --output-last-message', () => {
+  it('codex writes the final message to outFile via exec --output-last-message (with overlay)', () => {
     const a = adapterFor('codex');
     expect(a.headlessCaptureToFile).toBe(true);
-    expect(a.headlessArgs('hi', '/tmp/out.txt')).toEqual(['exec', '--output-last-message', '/tmp/out.txt', 'hi']);
-    expect(a.headlessArgs('hi')).toEqual(['exec', 'hi']);
+    expect(a.headlessArgs('hi', '/tmp/out.txt')).toEqual(['-p', 'aimux', 'exec', '--output-last-message', '/tmp/out.txt', 'hi']);
+    expect(a.headlessArgs('hi')).toEqual(['-p', 'aimux', 'exec', 'hi']);
+  });
+});
+
+describe('codex overlay (globalArgs + extraLinks)', () => {
+  it('injects -p aimux for runtime invocations (interactive, exec, resume) but not management', () => {
+    const a = adapterFor('codex');
+    expect(a.globalArgs(undefined)).toEqual(['-p', 'aimux']); // interactive
+    expect(a.globalArgs('--model')).toEqual(['-p', 'aimux']); // leading flag
+    expect(a.globalArgs('resume')).toEqual(['-p', 'aimux']);
+    expect(a.globalArgs('exec')).toEqual(['-p', 'aimux']);
+    expect(a.globalArgs('plugin')).toEqual([]); // management subcommand rejects -p
+    expect(a.globalArgs('doctor')).toEqual([]);
+    expect(a.globalArgs('login')).toEqual([]);
+  });
+
+  it('claude injects no global args', () => {
+    expect(adapterFor('claude').globalArgs(undefined)).toEqual([]);
+    expect(adapterFor('claude').globalArgs('mcp')).toEqual([]);
+  });
+
+  it('codex extra links: overlay config + plugins from the source', () => {
+    const links = adapterFor('codex').extraLinks('/home/u/.codex');
+    expect(links).toEqual([
+      { link: 'aimux.config.toml', target: '/home/u/.codex/config.toml' },
+      { link: 'plugins', target: '/home/u/.codex/plugins' },
+    ]);
+  });
+
+  it('claude has no extra links', () => {
+    expect(adapterFor('claude').extraLinks('/home/u/.claude')).toEqual([]);
   });
 });

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -66,8 +66,9 @@ export const codexAdapter: CliAdapter = {
   },
 
   resumeArgs(sessionId) {
-    // codex resume <uuid> (runtime → carries the overlay); no fork-on-resume flag.
-    return ['-p', OVERLAY_PROFILE, 'resume', sessionId];
+    // codex resume <uuid>; no fork-on-resume flag. The `-p aimux` overlay is added by the
+    // single injection point: globalArgs() (callers prepend it, incl. resumeSession).
+    return ['resume', sessionId];
   },
 
   headlessArgs(prompt, outFile) {

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { looksLikeSubcommand } from '../subcommand.js';
 import type { CliAdapter } from './types.js';
 
@@ -8,8 +9,27 @@ import type { CliAdapter } from './types.js';
 //   - session transcripts: sessions/ + session_index.jsonl — the codex analogue of
 //     claude's shared projects/. Sharing them is what lets you switch codex
 //     subscriptions and `codex resume` the SAME session under another profile.
-// Plugins are added in a later PR.
+// Settings + plugins are shared via the config OVERLAY (see extraLinks/globalArgs):
+// `config.toml` itself stays PRIVATE (codex churns it with trust-levels/runtime state),
+// but a symlinked `aimux.config.toml` overlay — which codex only READS, never writes —
+// carries the source's model/features/[plugins]/[marketplaces] when layered via `-p aimux`.
 const CODEX_SHARED_ENTRIES = new Set(['skills', 'rules', 'memories', 'sessions', 'session_index.jsonl']);
+
+// The overlay profile name: codex layers `$CODEX_HOME/<name>.config.toml` on top of the
+// base config when invoked with `-p <name>`. Verified: codex reads it, never writes it.
+const OVERLAY_PROFILE = 'aimux';
+
+// Codex subcommands that accept `-p` (runtime). Management subcommands (plugin, doctor,
+// login, logout, update, completion) reject it, so the overlay is skipped for them.
+const CODEX_RUNTIME_SUBCOMMANDS = new Set([
+  'exec', 'review', 'resume', 'archive', 'unarchive', 'fork', 'mcp', 'sandbox',
+]);
+
+function isRuntimeInvocation(firstArg: string | undefined): boolean {
+  if (!firstArg) return true; // interactive
+  if (firstArg.startsWith('-')) return true; // leading flag → interactive
+  return CODEX_RUNTIME_SUBCOMMANDS.has(firstArg);
+}
 
 export const codexAdapter: CliAdapter = {
   id: 'codex',
@@ -46,15 +66,29 @@ export const codexAdapter: CliAdapter = {
   },
 
   resumeArgs(sessionId) {
-    // codex resume <uuid>; codex has no fork-on-resume flag.
-    return ['resume', sessionId];
+    // codex resume <uuid> (runtime → carries the overlay); no fork-on-resume flag.
+    return ['-p', OVERLAY_PROFILE, 'resume', sessionId];
   },
 
   headlessArgs(prompt, outFile) {
     // codex exec stdout is noisy (header, token counts, echo). --output-last-message
     // writes ONLY the final assistant message, so the summarizer reads a clean result.
-    return outFile ? ['exec', '--output-last-message', outFile, prompt] : ['exec', prompt];
+    const head = ['-p', OVERLAY_PROFILE, 'exec'];
+    return outFile ? [...head, '--output-last-message', outFile, prompt] : [...head, prompt];
   },
 
   headlessCaptureToFile: true,
+
+  globalArgs(firstArg) {
+    return isRuntimeInvocation(firstArg) ? ['-p', OVERLAY_PROFILE] : [];
+  },
+
+  extraLinks(sourceDir) {
+    // Overlay (settings + plugin metadata) + plugin content. config.toml is read via the
+    // overlay symlink; codex never writes the overlay, so the symlink is safe.
+    return [
+      { link: `${OVERLAY_PROFILE}.config.toml`, target: join(sourceDir, 'config.toml') },
+      { link: 'plugins', target: join(sourceDir, 'plugins') },
+    ];
+  },
 };

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -73,7 +73,9 @@ export const codexAdapter: CliAdapter = {
   headlessArgs(prompt, outFile) {
     // codex exec stdout is noisy (header, token counts, echo). --output-last-message
     // writes ONLY the final assistant message, so the summarizer reads a clean result.
-    const head = ['-p', OVERLAY_PROFILE, 'exec'];
+    // No `-p aimux` here: headless goes through buildRunParams, whose globalArgs() injects
+    // the overlay for the runtime `exec` subcommand — adding it here would double it.
+    const head = ['exec'];
     return outFile ? [...head, '--output-last-message', outFile, prompt] : [...head, prompt];
   },
 

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -1,10 +1,15 @@
 import { looksLikeSubcommand } from '../subcommand.js';
 import type { CliAdapter } from './types.js';
 
-// Codex keeps creds/state in many top-level files (auth.json, config.toml, sessions/,
-// sqlite DBs, …). Sharing is an ALLOWLIST of knowledge dirs, not a denylist — so new
-// codex state files are never accidentally shared. Plugins are added in a later PR.
-const CODEX_SHARED_DIRS = new Set(['skills', 'rules', 'memories']);
+// Codex keeps creds/state in many top-level files (auth.json, config.toml, logs, sqlite
+// DBs, …). Sharing is an ALLOWLIST, not a denylist — new codex state files are never
+// accidentally shared. We share:
+//   - knowledge: skills, rules, memories
+//   - session transcripts: sessions/ + session_index.jsonl — the codex analogue of
+//     claude's shared projects/. Sharing them is what lets you switch codex
+//     subscriptions and `codex resume` the SAME session under another profile.
+// Plugins are added in a later PR.
+const CODEX_SHARED_ENTRIES = new Set(['skills', 'rules', 'memories', 'sessions', 'session_index.jsonl']);
 
 export const codexAdapter: CliAdapter = {
   id: 'codex',
@@ -25,7 +30,7 @@ export const codexAdapter: CliAdapter = {
   },
 
   isShared(entry) {
-    return CODEX_SHARED_DIRS.has(entry);
+    return CODEX_SHARED_ENTRIES.has(entry);
   },
 
   authArgs() {

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -49,4 +49,16 @@ export interface CliAdapter {
   /** True when headless output must be read from `outFile` (codex) rather than stdout
    *  (claude). The summarizer uses this to capture a clean result. */
   headlessCaptureToFile: boolean;
+
+  /** Global flags prepended to a `run` invocation (before the subcommand/model flags).
+   *  claude needs none; codex injects `-p aimux` for RUNTIME invocations so the shared
+   *  settings/plugins overlay layers on top. `firstArg` is the first passthrough arg,
+   *  used to skip non-runtime subcommands (plugin/doctor/login) that reject `-p`. */
+  globalArgs(firstArg: string | undefined): string[];
+
+  /** Extra symlinks to create in a profile beyond the shared source entries. Each is
+   *  `{ link }` (name inside the profile dir) → `{ target }` (absolute path). codex uses
+   *  this for its config overlay (`aimux.config.toml` → source `config.toml`) and plugin
+   *  content. `sourceDir` is the CLI's source-of-truth dir. */
+  extraLinks(sourceDir: string): Array<{ link: string; target: string }>;
 }

--- a/src/core/apiProfile.ts
+++ b/src/core/apiProfile.ts
@@ -18,8 +18,9 @@ export interface ProviderPreset {
   label: string;
   baseUrl: string;
   /** Model mapped to ANTHROPIC_MODEL / opus / sonnet / haiku. Third-party providers
-   *  usually expose one strong model; the small one (if any) maps to haiku/subagent. */
-  models: { default: string; opus: string; sonnet: string; haiku: string };
+   *  usually expose one strong model — set only `default` then; `opus`/`sonnet`/`haiku`
+   *  override per tier and otherwise fall back to `default`. */
+  models: { default: string; opus?: string; sonnet?: string; haiku?: string };
 }
 
 /**
@@ -32,44 +33,45 @@ export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
   deepseek: {
     label: 'DeepSeek',
     baseUrl: 'https://api.deepseek.com/anthropic',
-    models: { default: 'deepseek-chat', opus: 'deepseek-reasoner', sonnet: 'deepseek-chat', haiku: 'deepseek-chat' },
+    models: { default: 'deepseek-chat', opus: 'deepseek-reasoner' },
   },
   kimi: {
     label: 'Kimi (Moonshot)',
     baseUrl: 'https://api.moonshot.ai/anthropic',
-    models: { default: 'kimi-k2.5', opus: 'kimi-k2.5', sonnet: 'kimi-k2.5', haiku: 'kimi-k2.5' },
+    models: { default: 'kimi-k2.5' },
   },
   glm: {
     label: 'GLM (Z.ai)',
     baseUrl: 'https://api.z.ai/api/anthropic',
-    models: { default: 'glm-5.1', opus: 'glm-5.1', sonnet: 'glm-5.1', haiku: 'glm-4.5-air' },
+    models: { default: 'glm-5.1', haiku: 'glm-4.5-air' },
   },
   qwen: {
     label: 'Qwen (Alibaba DashScope)',
     baseUrl: 'https://dashscope-intl.aliyuncs.com/apps/anthropic',
-    models: { default: 'qwen3.6-plus', opus: 'qwen3.6-plus', sonnet: 'qwen3.6-plus', haiku: 'qwen3.6-plus' },
+    models: { default: 'qwen3.6-plus' },
   },
   minimax: {
     label: 'MiniMax',
     baseUrl: 'https://api.minimax.io/anthropic',
-    models: { default: 'minimax-m2.7', opus: 'minimax-m2.7', sonnet: 'minimax-m2.7', haiku: 'minimax-m2.7' },
+    models: { default: 'minimax-m2.7' },
   },
   mimo: {
     label: 'Xiaomi MiMo',
     baseUrl: 'https://api.xiaomimimo.com',
-    models: { default: 'mimo-v2-pro', opus: 'mimo-v2-pro', sonnet: 'mimo-v2-pro', haiku: 'mimo-v2-pro' },
+    models: { default: 'mimo-v2-pro' },
   },
 };
 
 /** The dotenv vars for a provider preset (+ token if given). Pure — used by both the
  *  interactive `--provider` flow and tests. */
 export function providerEnv(preset: ProviderPreset, token?: string): Record<string, string> {
+  const m = preset.models;
   const vars: Record<string, string> = {
     ANTHROPIC_BASE_URL: preset.baseUrl,
-    ANTHROPIC_MODEL: preset.models.default,
-    ANTHROPIC_DEFAULT_OPUS_MODEL: preset.models.opus,
-    ANTHROPIC_DEFAULT_SONNET_MODEL: preset.models.sonnet,
-    ANTHROPIC_DEFAULT_HAIKU_MODEL: preset.models.haiku,
+    ANTHROPIC_MODEL: m.default,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: m.opus ?? m.default,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: m.sonnet ?? m.default,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: m.haiku ?? m.default,
   };
   if (token) vars.ANTHROPIC_AUTH_TOKEN = token;
   return vars;

--- a/src/core/apiProfile.ts
+++ b/src/core/apiProfile.ts
@@ -14,6 +14,67 @@ export const API_MODEL_DEFAULTS = {
   ANTHROPIC_DEFAULT_HAIKU_MODEL: 'claude-haiku-4-5',
 } as const;
 
+export interface ProviderPreset {
+  label: string;
+  baseUrl: string;
+  /** Model mapped to ANTHROPIC_MODEL / opus / sonnet / haiku. Third-party providers
+   *  usually expose one strong model; the small one (if any) maps to haiku/subagent. */
+  models: { default: string; opus: string; sonnet: string; haiku: string };
+}
+
+/**
+ * Ready-made Anthropic-compatible providers that run on the claude CLI by only
+ * changing ANTHROPIC_BASE_URL + token. Base URLs are stable; model names drift, so
+ * update with `aimux profile update <name> -e ANTHROPIC_MODEL=…` when a provider
+ * renames. (Verified 2026-06.)
+ */
+export const PROVIDER_PRESETS: Record<string, ProviderPreset> = {
+  deepseek: {
+    label: 'DeepSeek',
+    baseUrl: 'https://api.deepseek.com/anthropic',
+    models: { default: 'deepseek-chat', opus: 'deepseek-reasoner', sonnet: 'deepseek-chat', haiku: 'deepseek-chat' },
+  },
+  kimi: {
+    label: 'Kimi (Moonshot)',
+    baseUrl: 'https://api.moonshot.ai/anthropic',
+    models: { default: 'kimi-k2.5', opus: 'kimi-k2.5', sonnet: 'kimi-k2.5', haiku: 'kimi-k2.5' },
+  },
+  glm: {
+    label: 'GLM (Z.ai)',
+    baseUrl: 'https://api.z.ai/api/anthropic',
+    models: { default: 'glm-5.1', opus: 'glm-5.1', sonnet: 'glm-5.1', haiku: 'glm-4.5-air' },
+  },
+  qwen: {
+    label: 'Qwen (Alibaba DashScope)',
+    baseUrl: 'https://dashscope-intl.aliyuncs.com/apps/anthropic',
+    models: { default: 'qwen3.6-plus', opus: 'qwen3.6-plus', sonnet: 'qwen3.6-plus', haiku: 'qwen3.6-plus' },
+  },
+  minimax: {
+    label: 'MiniMax',
+    baseUrl: 'https://api.minimax.io/anthropic',
+    models: { default: 'minimax-m2.7', opus: 'minimax-m2.7', sonnet: 'minimax-m2.7', haiku: 'minimax-m2.7' },
+  },
+  mimo: {
+    label: 'Xiaomi MiMo',
+    baseUrl: 'https://api.xiaomimimo.com',
+    models: { default: 'mimo-v2-pro', opus: 'mimo-v2-pro', sonnet: 'mimo-v2-pro', haiku: 'mimo-v2-pro' },
+  },
+};
+
+/** The dotenv vars for a provider preset (+ token if given). Pure — used by both the
+ *  interactive `--provider` flow and tests. */
+export function providerEnv(preset: ProviderPreset, token?: string): Record<string, string> {
+  const vars: Record<string, string> = {
+    ANTHROPIC_BASE_URL: preset.baseUrl,
+    ANTHROPIC_MODEL: preset.models.default,
+    ANTHROPIC_DEFAULT_OPUS_MODEL: preset.models.opus,
+    ANTHROPIC_DEFAULT_SONNET_MODEL: preset.models.sonnet,
+    ANTHROPIC_DEFAULT_HAIKU_MODEL: preset.models.haiku,
+  };
+  if (token) vars.ANTHROPIC_AUTH_TOKEN = token;
+  return vars;
+}
+
 /**
  * Sequential line reader over a single stdin consumer. Reading multiple
  * prompts via repeated `readline.createInterface()` drops buffered input on
@@ -167,6 +228,20 @@ export async function collectApiCredentials(): Promise<Record<string, string>> {
     }
 
     return vars;
+  } finally {
+    reader.close();
+  }
+}
+
+/**
+ * Provider-preset flow: fills base URL + model mapping from {@link PROVIDER_PRESETS}
+ * and prompts ONLY for the API token. Returns the env var map to persist.
+ */
+export async function collectProviderCredentials(preset: ProviderPreset): Promise<Record<string, string>> {
+  const reader = new StdinLineReader();
+  try {
+    const token = await reader.question(`  ${preset.label} API token:  `, true);
+    return providerEnv(preset, token || undefined);
   } finally {
     reader.close();
   }

--- a/src/core/apiProfile.ts
+++ b/src/core/apiProfile.ts
@@ -241,7 +241,12 @@ export async function collectProviderCredentials(preset: ProviderPreset): Promis
   const reader = new StdinLineReader();
   try {
     const token = await reader.question(`  ${preset.label} API token:  `, true);
-    return providerEnv(preset, token || undefined);
+    if (!token) {
+      // A base-URL preset without a token yields an unusable profile that `aimux status`
+      // would still report as healthy — fail loudly instead.
+      throw new Error('No API token entered — provider profile not created');
+    }
+    return providerEnv(preset, token);
   } finally {
     reader.close();
   }

--- a/src/core/codexSessionScanner.test.ts
+++ b/src/core/codexSessionScanner.test.ts
@@ -40,6 +40,27 @@ describe('scanCodexInteractive', () => {
     expect(out[0].createdAtMs).toBe(Date.parse('2026-06-18T10:05:23.926Z'));
   });
 
+  it('skips codex context preamble (environment_context / AGENTS.md) for the intent', () => {
+    rollout(join(SRC, 'sessions', '2026', '06', '19'), 'rollout-2026-06-19T08-00-00-22222222-2222-2222-2222-222222222222.jsonl', [
+      { timestamp: '2026-06-19T08:00:00.000Z', type: 'session_meta', payload: { id: '22222222-2222-2222-2222-222222222222', cwd: '/p' } },
+      { timestamp: '2026-06-19T08:00:01.000Z', type: 'response_item', payload: { role: 'user', content: [{ type: 'input_text', text: '<environment_context>\ncwd=/p\n</environment_context>' }] } },
+      { timestamp: '2026-06-19T08:00:02.000Z', type: 'response_item', payload: { role: 'user', content: [{ type: 'input_text', text: '# AGENTS.md instructions for /p' }] } },
+      { timestamp: '2026-06-19T08:00:03.000Z', type: 'response_item', payload: { role: 'user', content: [{ type: 'input_text', text: 'refactor the parser' }] } },
+    ]);
+    const out = scanCodexInteractive(SRC);
+    expect(out).toHaveLength(1);
+    expect(out[0].intent).toBe('refactor the parser');
+  });
+
+  it('falls back to the first user message when every one looks like preamble', () => {
+    rollout(join(SRC, 'sessions', '2026', '06', '19'), 'rollout-2026-06-19T09-00-00-33333333-3333-3333-3333-333333333333.jsonl', [
+      { timestamp: '2026-06-19T09:00:00.000Z', type: 'session_meta', payload: { id: '33333333-3333-3333-3333-333333333333', cwd: '/p' } },
+      { timestamp: '2026-06-19T09:00:01.000Z', type: 'response_item', payload: { role: 'user', content: [{ type: 'input_text', text: '<environment_context>only</environment_context>' }] } },
+    ]);
+    const out = scanCodexInteractive(SRC);
+    expect(out[0].intent).toBe('<environment_context>only</environment_context>');
+  });
+
   it('falls back to the UUID in the filename when session_meta is missing an id', () => {
     rollout(join(SRC, 'sessions', '2026', '06', '18'), 'rollout-2026-06-18T09-00-00-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee.jsonl', [
       { timestamp: '2026-06-18T09:00:00.000Z', type: 'session_meta', payload: { cwd: '/x' } },

--- a/src/core/codexSessionScanner.ts
+++ b/src/core/codexSessionScanner.ts
@@ -77,6 +77,70 @@ function listRolloutFiles(sessionsRoot: string): string[] {
 
 /** Scan a codex source dir for interactive sessions, returning records compatible with
  *  the claude `InteractiveSession` shape so `unifyAllSessions` can merge both. */
+interface ParsedRollout {
+  sessionId: string;
+  cwd: string;
+  createdAtMs: number;
+  intent: string;
+  events: number;
+}
+
+interface CodexScanCacheEntry {
+  mtimeMs: number;
+  size: number;
+  result: ParsedRollout | null; // null => file yielded no session (skip)
+}
+
+// (path → (mtime,size)-keyed parse) so a warm re-scan on the AgentsView poll path reuses
+// the parse instead of re-reading + re-parsing every rollout. Mirrors sessionScanner's cache.
+const codexScanCache = new Map<string, CodexScanCacheEntry>();
+
+/** Parse one codex rollout file into its session fields, or null if it has no id. */
+function parseRollout(filePath: string): ParsedRollout | null {
+  let lines: string[];
+  try {
+    lines = readFileSync(filePath, 'utf-8').split('\n');
+  } catch {
+    return null;
+  }
+
+  let sessionId = '';
+  let cwd = '';
+  let createdAtMs = 0;
+  let intent = '';
+  let events = 0;
+
+  for (const raw of lines) {
+    if (!raw) continue;
+    const rec = parseJson(raw);
+    const payload = rec?.payload;
+    if (!rec || !payload) continue;
+
+    if (rec.type === 'session_meta') {
+      sessionId = payload.id ?? sessionId;
+      cwd = payload.cwd ?? cwd;
+      const t = Date.parse(rec.timestamp ?? payload.timestamp ?? '');
+      if (!Number.isNaN(t)) createdAtMs = t;
+    } else if (rec.type === 'response_item') {
+      events += 1;
+      if (payload.role === 'user') {
+        // First real prompt wins; while we still only have a codex context preamble
+        // (<environment_context>, AGENTS.md, …) keep overwriting until a real one shows.
+        const text = contentText(payload.content);
+        if (text && (!intent || isCodexPreamble(intent))) intent = text;
+      }
+    }
+  }
+
+  if (!sessionId) {
+    const m = /rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/.exec(filePath);
+    if (!m) return null;
+    sessionId = m[1];
+  }
+
+  return { sessionId, cwd, createdAtMs, intent, events };
+}
+
 export function scanCodexInteractive(sourceDir: string, opts: ScanCodexOptions = {}): InteractiveSession[] {
   const sessionsRoot = join(expandHome(sourceDir), 'sessions');
   if (!existsSync(sessionsRoot)) return [];
@@ -96,63 +160,27 @@ export function scanCodexInteractive(sourceDir: string, opts: ScanCodexOptions =
     }
     if (stat.mtimeMs < windowCutoff) continue;
 
-    let lines: string[];
-    try {
-      lines = readFileSync(filePath, 'utf-8').split('\n');
-    } catch {
-      continue;
+    // Warm path: file unchanged since last scan → reuse the parse (updatedAtMs still
+    // tracks live mtime). Cold path: parse fully and cache.
+    const cached = codexScanCache.get(filePath);
+    let result: ParsedRollout | null;
+    if (cached && cached.mtimeMs === stat.mtimeMs && cached.size === stat.size) {
+      result = cached.result;
+    } else {
+      result = parseRollout(filePath);
+      codexScanCache.set(filePath, { mtimeMs: stat.mtimeMs, size: stat.size, result });
     }
-
-    let sessionId = '';
-    let cwd = '';
-    let createdAtMs = 0;
-    let intent = '';
-    let firstUserText = '';
-    let events = 0;
-
-    for (const raw of lines) {
-      if (!raw) continue;
-      const rec = parseJson(raw);
-      const payload = rec?.payload;
-      if (!rec || !payload) continue;
-
-      if (rec.type === 'session_meta') {
-        sessionId = payload.id ?? sessionId;
-        cwd = payload.cwd ?? cwd;
-        const t = Date.parse(rec.timestamp ?? payload.timestamp ?? '');
-        if (!Number.isNaN(t)) createdAtMs = t;
-      } else if (rec.type === 'response_item') {
-        events += 1;
-        if (!intent && payload.role === 'user') {
-          const text = contentText(payload.content);
-          if (text) {
-            if (!firstUserText) firstUserText = text;
-            // codex prepends system/context blocks (<environment_context>, AGENTS.md,
-            // <permissions …>) as 'user' messages; the real prompt is the first that
-            // isn't one of those.
-            if (!isCodexPreamble(text)) intent = text;
-          }
-        }
-      }
-    }
-
-    if (!intent) intent = firstUserText;
-
-    if (!sessionId) {
-      const m = /rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/.exec(filePath);
-      if (m) sessionId = m[1];
-      else continue;
-    }
+    if (!result) continue;
 
     sessions.push({
-      sessionId,
-      cwd,
-      intent,
+      sessionId: result.sessionId,
+      cwd: result.cwd,
+      intent: result.intent,
       title: '',
       cwdHashDir: '',
-      createdAtMs: createdAtMs || stat.birthtimeMs || stat.mtimeMs,
+      createdAtMs: result.createdAtMs || stat.birthtimeMs || stat.mtimeMs,
       updatedAtMs: stat.mtimeMs,
-      events,
+      events: result.events,
     });
   }
 

--- a/src/core/codexSessionScanner.ts
+++ b/src/core/codexSessionScanner.ts
@@ -35,6 +35,14 @@ function contentText(content: unknown): string {
   return '';
 }
 
+// codex injects context as the first 'user' message(s): an <environment_context> /
+// <permissions …> XML block, or the project's AGENTS.md instructions. These aren't the
+// real prompt, so they're skipped when deriving a session's intent/name.
+function isCodexPreamble(text: string): boolean {
+  const t = text.trimStart();
+  return t.startsWith('<') || t.startsWith('# AGENTS.md') || t.startsWith('# Instructions');
+}
+
 function listRolloutFiles(sessionsRoot: string): string[] {
   const out: string[] = [];
   const stack = [sessionsRoot];
@@ -93,6 +101,7 @@ export function scanCodexInteractive(sourceDir: string, opts: ScanCodexOptions =
     let cwd = '';
     let createdAtMs = 0;
     let intent = '';
+    let firstUserText = '';
     let events = 0;
 
     for (const raw of lines) {
@@ -109,10 +118,19 @@ export function scanCodexInteractive(sourceDir: string, opts: ScanCodexOptions =
       } else if (rec.type === 'response_item') {
         events += 1;
         if (!intent && payload.role === 'user') {
-          intent = contentText(payload.content);
+          const text = contentText(payload.content);
+          if (text) {
+            if (!firstUserText) firstUserText = text;
+            // codex prepends system/context blocks (<environment_context>, AGENTS.md,
+            // <permissions …>) as 'user' messages; the real prompt is the first that
+            // isn't one of those.
+            if (!isCodexPreamble(text)) intent = text;
+          }
         }
       }
     }
+
+    if (!intent) intent = firstUserText;
 
     if (!sessionId) {
       const m = /rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/.exec(filePath);

--- a/src/core/codexSessionScanner.ts
+++ b/src/core/codexSessionScanner.ts
@@ -40,7 +40,13 @@ function contentText(content: unknown): string {
 // real prompt, so they're skipped when deriving a session's intent/name.
 function isCodexPreamble(text: string): boolean {
   const t = text.trimStart();
-  return t.startsWith('<') || t.startsWith('# AGENTS.md') || t.startsWith('# Instructions');
+  return (
+    t.startsWith('<environment_context') ||
+    t.startsWith('<permissions') ||
+    t.startsWith('<user_instructions') ||
+    t.startsWith('# AGENTS.md') ||
+    t.startsWith('# Instructions')
+  );
 }
 
 function listRolloutFiles(sessionsRoot: string): string[] {

--- a/src/core/codexSharing.test.ts
+++ b/src/core/codexSharing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, writeFileSync, lstatSync, existsSync } from 'node:fs';
+import { mkdirSync, rmSync, writeFileSync, lstatSync, existsSync, readlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { setAimuxDir } from './paths.js';
@@ -26,7 +26,7 @@ function config(): AimuxConfig {
 
 beforeEach(() => {
   // Codex source with a mix of knowledge dirs, shared transcripts, and private state.
-  for (const d of ['skills', 'rules', 'memories', 'sessions']) {
+  for (const d of ['skills', 'rules', 'memories', 'sessions', 'plugins']) {
     mkdirSync(join(CODEX_SRC, d), { recursive: true });
   }
   writeFileSync(join(CODEX_SRC, 'session_index.jsonl'), '');
@@ -60,9 +60,23 @@ describe('codex profile sharing (allowlist)', () => {
     const profileDir = join(PROFILES, 'codework');
     const result = syncProfile(config(), 'codework');
 
+    // config.toml stays private — settings are shared via the separate overlay symlink.
     for (const f of ['auth.json', 'config.toml', 'history.jsonl']) {
       expect(existsSync(join(profileDir, f)), `${f} must not be linked`).toBe(false);
       expect(result.private, `${f} reported private`).toContain(f);
     }
+  });
+
+  it('creates the config overlay (aimux.config.toml) and plugins symlink from the source', () => {
+    const profileDir = join(PROFILES, 'codework');
+    syncProfile(config(), 'codework');
+
+    const overlay = join(profileDir, 'aimux.config.toml');
+    expect(lstatSync(overlay).isSymbolicLink(), 'overlay should be a symlink').toBe(true);
+    expect(readlinkSync(overlay)).toBe(join(CODEX_SRC, 'config.toml'));
+
+    const plugins = join(profileDir, 'plugins');
+    expect(lstatSync(plugins).isSymbolicLink(), 'plugins should be a symlink').toBe(true);
+    expect(readlinkSync(plugins)).toBe(join(CODEX_SRC, 'plugins'));
   });
 });

--- a/src/core/codexSharing.test.ts
+++ b/src/core/codexSharing.test.ts
@@ -25,10 +25,11 @@ function config(): AimuxConfig {
 }
 
 beforeEach(() => {
-  // Codex source with a mix of knowledge dirs and private state.
+  // Codex source with a mix of knowledge dirs, shared transcripts, and private state.
   for (const d of ['skills', 'rules', 'memories', 'sessions']) {
     mkdirSync(join(CODEX_SRC, d), { recursive: true });
   }
+  writeFileSync(join(CODEX_SRC, 'session_index.jsonl'), '');
   writeFileSync(join(CODEX_SRC, 'auth.json'), '{}');
   writeFileSync(join(CODEX_SRC, 'config.toml'), 'model = "x"');
   writeFileSync(join(CODEX_SRC, 'history.jsonl'), '');
@@ -42,22 +43,24 @@ afterEach(() => {
 });
 
 describe('codex profile sharing (allowlist)', () => {
-  it('symlinks only knowledge dirs (skills/rules/memories) from the codex source', () => {
+  it('symlinks knowledge dirs and session transcripts from the codex source', () => {
     const profileDir = join(PROFILES, 'codework');
     syncProfile(config(), 'codework');
 
-    for (const d of ['skills', 'rules', 'memories']) {
-      const p = join(profileDir, d);
-      expect(existsSync(p), `${d} should be linked`).toBe(true);
-      expect(lstatSync(p).isSymbolicLink(), `${d} should be a symlink`).toBe(true);
+    // knowledge + shared transcripts (sessions/ and session_index.jsonl) — the latter
+    // is what lets a different codex subscription resume the same session.
+    for (const entry of ['skills', 'rules', 'memories', 'sessions', 'session_index.jsonl']) {
+      const p = join(profileDir, entry);
+      expect(existsSync(p), `${entry} should be linked`).toBe(true);
+      expect(lstatSync(p).isSymbolicLink(), `${entry} should be a symlink`).toBe(true);
     }
   });
 
-  it('does NOT share codex creds/state (auth.json, config.toml, history.jsonl, sessions)', () => {
+  it('does NOT share codex creds/state (auth.json, config.toml, history.jsonl)', () => {
     const profileDir = join(PROFILES, 'codework');
     const result = syncProfile(config(), 'codework');
 
-    for (const f of ['auth.json', 'config.toml', 'history.jsonl', 'sessions']) {
+    for (const f of ['auth.json', 'config.toml', 'history.jsonl']) {
       expect(existsSync(join(profileDir, f)), `${f} must not be linked`).toBe(false);
       expect(result.private, `${f} reported private`).toContain(f);
     }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -55,12 +55,16 @@ export type { OpenSessionOptions, SessionEvent, TurnResult, LiveSession } from '
 
 export {
   collectApiCredentials,
+  collectProviderCredentials,
+  providerEnv,
+  PROVIDER_PRESETS,
   writeProfileDotEnv,
   mergeProfileDotEnv,
   checkDotenvPermissions,
   seedApiClaudeJson,
   API_MODEL_DEFAULTS,
 } from './apiProfile.js';
+export type { ProviderPreset } from './apiProfile.js';
 
 export { summarizeUsage, usageBySession, parseSinceDuration, totalTokens } from './usage.js';
 export type { ProfileUsageSummary, SessionUsageSummary, UsageOptions, UsageTotals } from './usage.js';

--- a/src/core/providerPresets.test.ts
+++ b/src/core/providerPresets.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { PROVIDER_PRESETS, providerEnv } from './apiProfile.js';
+
+describe('PROVIDER_PRESETS', () => {
+  it('covers the verified Anthropic-compatible providers with anthropic base URLs', () => {
+    expect(PROVIDER_PRESETS.deepseek.baseUrl).toBe('https://api.deepseek.com/anthropic');
+    expect(PROVIDER_PRESETS.kimi.baseUrl).toBe('https://api.moonshot.ai/anthropic');
+    expect(PROVIDER_PRESETS.glm.baseUrl).toBe('https://api.z.ai/api/anthropic');
+    expect(PROVIDER_PRESETS.qwen.baseUrl).toBe('https://dashscope-intl.aliyuncs.com/apps/anthropic');
+    expect(PROVIDER_PRESETS.minimax.baseUrl).toBe('https://api.minimax.io/anthropic');
+    expect(PROVIDER_PRESETS.mimo.baseUrl).toBe('https://api.xiaomimimo.com');
+  });
+});
+
+describe('providerEnv', () => {
+  it('maps base URL + model tiers from a preset', () => {
+    const env = providerEnv(PROVIDER_PRESETS.deepseek);
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://api.deepseek.com/anthropic');
+    expect(env.ANTHROPIC_MODEL).toBe('deepseek-chat');
+    expect(env.ANTHROPIC_DEFAULT_OPUS_MODEL).toBe('deepseek-reasoner');
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('deepseek-chat');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
+  it('includes the token when provided', () => {
+    const env = providerEnv(PROVIDER_PRESETS.glm, 'sk-zai-123');
+    expect(env.ANTHROPIC_AUTH_TOKEN).toBe('sk-zai-123');
+    expect(env.ANTHROPIC_DEFAULT_HAIKU_MODEL).toBe('glm-4.5-air');
+  });
+});

--- a/src/core/run.ts
+++ b/src/core/run.ts
@@ -115,13 +115,14 @@ export function buildRunParams(
   const userPassedModel = extraArgs.some((a) => a === '--model' || a === '-m');
   const userPassedFallback = extraArgs.some((a) => a === '--fallback-model');
 
-  const args: string[] = adapter.modelArgs({
+  const args: string[] = adapter.globalArgs(firstExtra);
+  args.push(...adapter.modelArgs({
     model,
     fallbackModel: profile.fallback_model,
     isSubcommand,
     userPassedModel,
     userPassedFallback,
-  });
+  }));
   if (extraArgs.length > 0) {
     args.push(...extraArgs);
   }

--- a/src/core/sessionActions.ts
+++ b/src/core/sessionActions.ts
@@ -126,7 +126,11 @@ export async function resumeSession(
   options: { cwd?: string; forkSession?: boolean } = {},
 ): Promise<number> {
   const profile = getProfile(config, profileName);
-  const args = adapterFor(profile.cli).resumeArgs(sessionId, { fork: options.forkSession });
+  const adapter = adapterFor(profile.cli);
+  const rargs = adapter.resumeArgs(sessionId, { fork: options.forkSession });
+  // globalArgs() is the single overlay-injection point (e.g. codex `-p aimux`); resume
+  // spawns the CLI directly (not via buildRunParams), so prepend it here.
+  const args = [...adapter.globalArgs(rargs[0]), ...rargs];
   await prepareTtyForHandoff();
   return new Promise((resolve, reject) => {
     const child = spawn(profile.cli, args, {

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -337,16 +337,14 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     const linkPath = join(profilePath, link);
     if (lstatExists(linkPath)) {
       const st = lstatSync(linkPath);
-      if (st.isSymbolicLink()) {
-        if (resolve(profilePath, readlinkSync(linkPath)) === resolve(target)) {
-          result.skipped.push(link);
-        } else {
-          unlinkSync(linkPath);
-          symlinkSync(target, linkPath);
-          result.repaired.push(link);
-        }
-      } else {
+      if (!st.isSymbolicLink()) {
         result.conflicts.push(link);
+      } else if (symlinkTargetMatches(profilePath, linkPath, target)) {
+        result.skipped.push(link);
+      } else {
+        unlinkSync(linkPath);
+        symlinkSync(target, linkPath);
+        result.repaired.push(link);
       }
       continue;
     }
@@ -455,8 +453,7 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
       report.missing.push(link);
       continue;
     }
-    const st = lstatSync(linkPath);
-    const ok = st.isSymbolicLink() && resolve(profilePath, readlinkSync(linkPath)) === resolve(target) && existsSync(linkPath);
+    const ok = lstatSync(linkPath).isSymbolicLink() && symlinkTargetMatches(profilePath, linkPath, target);
     report[ok ? 'valid' : 'broken'].push(link);
   }
 
@@ -469,6 +466,11 @@ export function checkAllProfiles(config: AimuxConfig): Map<string, HealthReport>
     reports.set(name, checkProfileHealth(config, name));
   }
   return reports;
+}
+
+/** Whether the symlink at `linkPath` resolves to `target` (relative to `fromDir`). */
+function symlinkTargetMatches(fromDir: string, linkPath: string, target: string): boolean {
+  return resolve(fromDir, readlinkSync(linkPath)) === resolve(target);
 }
 
 function lstatExists(p: string): boolean {

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -447,6 +447,9 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
   // Per-CLI extra symlinks (codex overlay + plugins). They are not source entries, so
   // they're validated here rather than in the loops above.
   for (const { link, target } of adapter.extraLinks(sourcePath)) {
+    // syncProfile only creates an extra link when its source target exists; mirror that
+    // here so an absent optional source (e.g. no ~/.codex/plugins) isn't a false 'missing'.
+    if (!existsSync(target)) continue;
     const linkPath = join(profilePath, link);
     if (!lstatExists(linkPath)) {
       report.missing.push(link);

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -331,6 +331,31 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     }
   }
 
+  // Per-CLI extra symlinks (codex config overlay + plugin content) — names that do not
+  // exist as source entries, so they are created beyond the readdir loop above.
+  for (const { link, target } of adapter.extraLinks(sourcePath)) {
+    const linkPath = join(profilePath, link);
+    if (lstatExists(linkPath)) {
+      const st = lstatSync(linkPath);
+      if (st.isSymbolicLink()) {
+        if (resolve(profilePath, readlinkSync(linkPath)) === resolve(target)) {
+          result.skipped.push(link);
+        } else {
+          unlinkSync(linkPath);
+          symlinkSync(target, linkPath);
+          result.repaired.push(link);
+        }
+      } else {
+        result.conflicts.push(link);
+      }
+      continue;
+    }
+    if (existsSync(target)) {
+      symlinkSync(target, linkPath);
+      result.created.push(link);
+    }
+  }
+
   return result;
 }
 
@@ -417,6 +442,19 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
         report.orphaned.push(entry);
       }
     }
+  }
+
+  // Per-CLI extra symlinks (codex overlay + plugins). They are not source entries, so
+  // they're validated here rather than in the loops above.
+  for (const { link, target } of adapter.extraLinks(sourcePath)) {
+    const linkPath = join(profilePath, link);
+    if (!lstatExists(linkPath)) {
+      report.missing.push(link);
+      continue;
+    }
+    const st = lstatSync(linkPath);
+    const ok = st.isSymbolicLink() && resolve(profilePath, readlinkSync(linkPath)) === resolve(target) && existsSync(linkPath);
+    report[ok ? 'valid' : 'broken'].push(link);
   }
 
   return report;


### PR DESCRIPTION
## What — 0.17.0

Codex profiles reach **full parity with claude**, plus one-command **provider presets** for Anthropic-compatible models. Builds on 0.16.0's multi-CLI foundation. **claude is byte-for-byte unchanged; everything is opt-in.**

### Codex: full sharing parity
- **Session transcripts** shared across codex profiles (`sessions/` + `session_index.jsonl`) — the codex analogue of claude's shared `projects/`. Switching codex subscriptions can `codex resume` the same session.
- **Settings + plugins** shared via codex's native config overlay: a symlinked `aimux.config.toml` layered with `-p aimux` (codex reads it, never writes it — verified against codex-cli 0.139.0). The mutable `config.toml` stays private. No TOML dependency, no merge — pure symlink + flag.
- Knowledge (`skills`/`rules`/`memories`) already shared in 0.16.0.

### Provider presets (Anthropic-compatible models)
- `aimux profile add <name> --provider <deepseek|kimi|glm|qwen|minimax|mimo>` fills the provider's `ANTHROPIC_BASE_URL` + model mapping, prompts only for the token.
- These run on the **claude CLI** (`cli: claude`), so they share the full claude brain and you can `--resume` a claude session under them natively — switching the model mid-session, no summary handoff.

### Fixes
- Codex auth shown correctly in profile list / `aimux auth status` (routed through `adapter.credentialsFile()` → `auth.json`).
- Codex session names in `aimux agents` skip the injected context preamble (`<environment_context>`/AGENTS.md).
- `aimux init` detects `~/.codex` and pre-registers `shared_sources.codex`.

## Backward compatibility
claude adapter's new methods are neutral (`globalArgs()`→[], `extraLinks()`→[]); `buildRunParams`/`syncProfile`/`checkProfileHealth`/auth are unchanged for claude — confirmed by the run-path and symlinks characterization tests. All new config/APIs additive. aimux stays self-contained (no Loom dependency).

## Verification
- `npx vitest run` → **252/252 pass**
- `npx tsc -p tsconfig.build.json --noEmit` → clean
- Independent code review (regression + cleanup) applied; codex `-p` injection consolidated to a single source; codex scanner given a parse cache.

## Out of scope (later)
Gemini CLI adapter; cross-CLI handoff from the agents TUI; per-CLI usage pricing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
