### PR TITLE
feat(use): per-shell profile switch (aimux use + shell-init)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.18.0] - 2026-06-24
+
+### Added
+- **Switch your shell to a profile (`aimux use`).** Activate a profile in the
+  current shell so plain `claude` / `codex` run under it — the `nvm use` / `pyenv
+  shell` model, an alternative to per-launch `aimux run`. Enable once with
+  `eval "$(aimux shell-init)"` in your rc (bash/zsh/fish supported), then:
+  - `aimux use <profile>` exports the profile's env (the CLI adapter picks
+    `CLAUDE_CONFIG_DIR` vs `CODEX_HOME`, plus any profile `.env`) into the
+    current shell. No name → interactive picker.
+  - Switching profiles cleans up the previous profile's managed vars (stale
+    `ANTHROPIC_*` / tokens), so no credentials leak across a switch.
+  - Each shell is independent — different terminals can hold different active
+    profiles at once, preserving aimux's "any profile, any terminal" model.
+  - `aimux shell-init [--shell <bash|zsh|fish>]` prints the wrapper function.
+- **`aimux status` / `profile list` mark the in-use profile.** The profile
+  activated in the current shell is highlighted with a `▸` marker and an
+  `Active here:` summary line (read from `$AIMUX_PROFILE`, ignored if stale).
+
 ## [0.17.0] - 2026-06-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -96,6 +96,31 @@ aimux profile update w --fallback-model claude-sonnet-4-6
 aimux profile update w --unset-fallback-model   # remove it
 ```
 
+### Switch your shell to a profile (`aimux use`)
+
+`aimux run` launches a one-off session. If you'd rather *activate* a profile so
+plain `claude` / `codex` use it — like `nvm use` or `pyenv shell` — enable the
+shell integration once:
+
+```bash
+# add to ~/.zshrc or ~/.bashrc (fish: ~/.config/fish/config.fish)
+eval "$(aimux shell-init)"
+```
+
+Then:
+
+```bash
+aimux use work     # activate 'work' in this shell (persistent until you switch)
+claude             # runs under 'work' — no `aimux run` needed
+codex              # same; the CLI adapter sets CODEX_HOME for you
+aimux use api      # switch profiles — stale ANTHROPIC_*/tokens are cleaned up
+aimux use          # no name → interactive picker
+```
+
+Each shell is independent, so different terminals can hold different active
+profiles at once. The switch only exports env vars into the current shell — it
+never changes global state. `aimux run` still works for one-off launches.
+
 ## Commands
 
 | Command | Description |
@@ -109,6 +134,8 @@ aimux profile update w --unset-fallback-model   # remove it
 | `aimux run` | Interactive picker — history pre-selects last used profile |
 | `aimux run w` | Prefix matching — launches `work` if unambiguous |
 | `aimux run work -m claude-sonnet-4-6` | Launch with model override |
+| `aimux use [profile]` | Switch the current shell to a profile (persistent) — plain `claude`/`codex` then use it. Requires `eval "$(aimux shell-init)"` in your rc |
+| `aimux shell-init` | Print the shell function that enables `aimux use` (add to `~/.zshrc`/`~/.bashrc`/fish config) |
 | `aimux agents` | Multi-profile agent view — see and manage claude background sessions across **all** profiles in one TUI |
 | `aimux profile add <name>` | Create new profile with symlinks |
 | `aimux profile add <name> --api` | Create a 3rd-party API profile (interactive endpoint + token prompt) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -14,6 +14,7 @@ import {
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
   loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson,
+  parseShell, buildSwitchEnv, renderShellExports, renderShellInit,
 } from './core/index.js';
 
 function collectRepeatable(value: string, previous: string[]): string[] {
@@ -245,6 +246,104 @@ program
       }
       const exitCode = await launchProfile(config, profileName, { model: options.model, extraArgs: cliArgs });
       process.exit(exitCode);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('use [profile]')
+  .description('Switch the current shell to a profile (persistent until you switch again)')
+  .option('--export', 'Emit shell export statements for eval (used by the shell wrapper)')
+  .option('--shell <shell>', 'Target shell for --export: bash, zsh, or fish')
+  .action(async (profile: string | undefined, options: { export?: boolean; shell?: string }) => {
+    try {
+      const config = requireConfig();
+
+      const shell = parseShell(options.shell, process.env.SHELL);
+
+      let profileName = profile;
+      if (!profileName) {
+        const names = Object.keys(config.profiles);
+        if (names.length === 1) {
+          profileName = names[0];
+        } else {
+          const { render } = await import('ink');
+          const { ProfilePicker } = await import('./components/ProfilePicker.js');
+          const last = getLastProfile(process.cwd());
+          let selected: string | undefined;
+          // Under the shell wrapper, --export's stdout is captured by command
+          // substitution, so draw the picker on stderr (still a TTY) to keep
+          // stdout eval-clean. Direct invocation draws on stdout as usual.
+          const { waitUntilExit } = render(
+            <ProfilePicker config={config} lastProfile={last} onSelect={(s: string) => { selected = s; }} />,
+            options.export ? { stdout: process.stderr } : undefined,
+          );
+          await waitUntilExit();
+          if (!selected) return;
+          profileName = selected;
+        }
+      }
+
+      profileName = resolveProfile(config, profileName);
+      const profile_ = config.profiles[profileName];
+
+      // Keep the runtime dir fresh, same as `run`. Source profiles need no sync.
+      if (!profile_.is_source) {
+        const sync = syncProfile(config, profileName);
+        // Only surface real repairs — switching is frequent, and a steady
+        // conflict count would spam every switch. stderr keeps stdout eval-clean.
+        if (sync.created.length > 0 || sync.repaired.length > 0) {
+          console.error(`Auto-sync: ${formatSyncSummary(sync)}`);
+        }
+      }
+      const permWarning = checkDotenvPermissions(expandHome(profile_.path));
+      if (permWarning) console.error(`\x1b[33m⚠ ${permWarning}\x1b[0m`);
+
+      recordHistory(process.cwd(), profileName);
+      const env = buildSwitchEnv(config, profileName);
+
+      if (options.export) {
+        // stdout: ONLY shell code (it gets eval'd). Confirmation goes to stderr.
+        process.stdout.write(
+          renderShellExports({ env, profileName, previousManaged: process.env.AIMUX_MANAGED, shell }) + '\n'
+        );
+        const bits: string[] = [];
+        if (env.ANTHROPIC_BASE_URL) {
+          try { bits.push(`endpoint ${new URL(env.ANTHROPIC_BASE_URL).host}`); }
+          catch { bits.push(`endpoint ${env.ANTHROPIC_BASE_URL}`); }
+        }
+        const model = env.ANTHROPIC_MODEL ?? profile_.model;
+        if (model) bits.push(`model ${model}`);
+        const suffix = bits.length > 0 ? ` — ${bits.join(', ')}` : '';
+        console.error(`Switched to '${profileName}' (${profile_.cli})${suffix}. Run \`${profile_.cli}\` to start.`);
+        return;
+      }
+
+      // Not eval'd — the user ran `aimux use` directly without shell integration.
+      console.error(`Profile '${profileName}' (${profile_.cli}) selected, but this shell was not updated.`);
+      console.error('Enable the shell wrapper once so `aimux use` switches in place:');
+      console.error('');
+      console.error(`  echo 'eval "$(aimux shell-init)"' >> ~/.${shell === 'fish' ? 'config/fish/config.fish' : `${shell}rc`}`);
+      console.error('');
+      console.error('Or switch just this once with:');
+      console.error(shell === 'fish'
+        ? `  eval (aimux use ${profileName} --export --shell fish | string collect)`
+        : `  eval "$(aimux use ${profileName} --export)"`);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('shell-init')
+  .description('Print the shell function enabling `aimux use` (add to your rc: eval "$(aimux shell-init)")')
+  .option('--shell <shell>', 'Target shell: bash, zsh, or fish')
+  .action((options: { shell?: string }) => {
+    try {
+      console.log(renderShellInit(parseShell(options.shell, process.env.SHELL)));
     } catch (err) {
       console.error(`Error: ${(err as Error).message}`);
       process.exit(1);

--- a/src/components/ProfilePicker.tsx
+++ b/src/components/ProfilePicker.tsx
@@ -23,6 +23,7 @@ export function ProfilePicker({ config, lastProfile, onSelect }: Props) {
       setCursor(prev => (prev < profiles.length - 1 ? prev + 1 : 0));
     } else if (key.return) {
       onSelect(profiles[cursor][0]);
+      exit(); // close the picker so render().waitUntilExit() resolves on select
     } else if (input === 'q' || key.escape) {
       exit();
     }

--- a/src/components/StatusView.tsx
+++ b/src/components/StatusView.tsx
@@ -90,6 +90,10 @@ export function StatusView({ config }: Props) {
   const sharedEntries = safeGetSharedElements(config);
   const sharedCount = sharedEntries.length;
   const reports = checkAllProfiles(config);
+  // The profile activated in THIS shell via `aimux use` (per-shell env var).
+  // Only honored when it resolves to a real profile, so a stale var never lies.
+  const envActive = process.env.AIMUX_PROFILE;
+  const activeProfile = envActive && config.profiles[envActive] ? envActive : undefined;
 
   return (
     <Box flexDirection="column" padding={1}>
@@ -100,11 +104,14 @@ export function StatusView({ config }: Props) {
         <Text>Profiles: <Text bold>{profiles.length}</Text> ({authCount} authenticated)</Text>
         <Text>Shared elements: <Text bold>{sharedCount}</Text></Text>
         <Text>Private elements: <Text bold>{config.private.length}</Text></Text>
+        <Text>Active here: {activeProfile
+          ? <Text bold color="green">{activeProfile}</Text>
+          : <Text dimColor>none (run `aimux use &lt;profile&gt;`)</Text>}</Text>
         <Text> </Text>
 
         <Box flexDirection="column">
           <Box gap={2}>
-            <Box width={12}><Text bold underline>NAME</Text></Box>
+            <Box width={12}><Text bold underline>{'  NAME'}</Text></Box>
             <Box width={16}><Text bold underline>AUTH</Text></Box>
             <Box width={20}><Text bold underline>MODEL</Text></Box>
             <Box width={16}><Text bold underline>AUTOMODE</Text></Box>
@@ -133,10 +140,13 @@ export function StatusView({ config }: Props) {
                   ? 'green'
                   : 'yellow';
 
+            const isActive = name === activeProfile;
             return (
               <Box key={name} gap={2}>
                 <Box width={12}>
-                  <Text color={isSource ? 'yellow' : 'white'}>{name}</Text>
+                  <Text color={isActive ? 'green' : isSource ? 'yellow' : 'white'} bold={isActive}>
+                    {isActive ? '▸ ' : '  '}{name}
+                  </Text>
                 </Box>
                 <Box width={16}>
                   {auth.kind === 'api'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -50,6 +50,8 @@ export { buildRunParams, launchProfile, runProfileHeadless, looksLikeSubcommand,
 export type { RunOptions, RunParams, HeadlessOptions, HeadlessResult } from './run.js';
 export { adapterFor } from './adapters/index.js';
 export type { CliAdapter } from './adapters/index.js';
+export { detectShell, parseShell, buildSwitchEnv, renderShellExports, renderShellInit } from './shellSwitch.js';
+export type { SupportedShell, RenderExportsOptions } from './shellSwitch.js';
 export { openSession, buildSessionArgs } from './liveSession.js';
 export type { OpenSessionOptions, SessionEvent, TurnResult, LiveSession } from './liveSession.js';
 

--- a/src/core/shellSwitch.test.ts
+++ b/src/core/shellSwitch.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { detectShell, parseShell, renderShellExports, renderShellInit } from './shellSwitch.js';
+
+describe('detectShell', () => {
+  it('detects zsh, fish, and falls back to bash', () => {
+    expect(detectShell('/bin/zsh')).toBe('zsh');
+    expect(detectShell('/usr/local/bin/fish')).toBe('fish');
+    expect(detectShell('/bin/bash')).toBe('bash');
+    expect(detectShell(undefined)).toBe('bash');
+    expect(detectShell('/usr/bin/sh')).toBe('bash');
+  });
+});
+
+describe('parseShell', () => {
+  it('returns an explicit valid shell', () => {
+    expect(parseShell('fish', '/bin/zsh')).toBe('fish');
+    expect(parseShell('bash', undefined)).toBe('bash');
+  });
+
+  it('falls back to detection from the shell path when no explicit value', () => {
+    expect(parseShell(undefined, '/usr/local/bin/fish')).toBe('fish');
+    expect(parseShell(undefined, undefined)).toBe('bash');
+  });
+
+  it('throws on an unsupported shell', () => {
+    expect(() => parseShell('powershell', '/bin/zsh')).toThrow(/Unsupported --shell/);
+  });
+});
+
+describe('renderShellExports', () => {
+  const env = { CLAUDE_CONFIG_DIR: '/home/u/.aimux/profiles/work', ANTHROPIC_BASE_URL: 'https://x.test' };
+
+  it('exports each var plus the profile + managed markers (posix)', () => {
+    const out = renderShellExports({ env, profileName: 'work', shell: 'zsh' });
+    expect(out).toContain(`export CLAUDE_CONFIG_DIR='/home/u/.aimux/profiles/work'`);
+    expect(out).toContain(`export ANTHROPIC_BASE_URL='https://x.test'`);
+    expect(out).toContain(`export AIMUX_PROFILE='work'`);
+    expect(out).toContain('export AIMUX_MANAGED=');
+    expect(out).toContain('CLAUDE_CONFIG_DIR ANTHROPIC_BASE_URL AIMUX_PROFILE');
+  });
+
+  it('unsets previously-managed vars that the new profile does not set', () => {
+    const out = renderShellExports({
+      env,
+      profileName: 'work',
+      previousManaged: 'ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN CLAUDE_CONFIG_DIR AIMUX_PROFILE',
+      shell: 'zsh',
+    });
+    // ANTHROPIC_AUTH_TOKEN is stale (not in the new env) -> unset; the rest are re-set.
+    expect(out).toMatch(/^unset ANTHROPIC_AUTH_TOKEN$/m);
+    expect(out).not.toMatch(/unset.*CLAUDE_CONFIG_DIR/);
+  });
+
+  it('escapes single quotes in values (posix)', () => {
+    const out = renderShellExports({ env: { K: "a'b" }, profileName: 'p', shell: 'bash' });
+    expect(out).toContain(`export K='a'\\''b'`);
+  });
+
+  it('uses fish syntax when targeting fish', () => {
+    const out = renderShellExports({ env, profileName: 'work', previousManaged: 'OLD_VAR', shell: 'fish' });
+    expect(out).toContain(`set -gx CLAUDE_CONFIG_DIR '/home/u/.aimux/profiles/work'`);
+    expect(out).toContain(`set -e OLD_VAR`);
+    expect(out).toContain(`set -gx AIMUX_PROFILE 'work'`);
+  });
+});
+
+describe('renderShellInit', () => {
+  it('emits a posix function that evals `use` and passes everything else through', () => {
+    const out = renderShellInit('zsh');
+    expect(out).toContain('aimux() {');
+    expect(out).toContain('if [ "$1" = "use" ]; then');
+    expect(out).toContain('command aimux use "$@" --export');
+    expect(out).toContain('command aimux "$@"');
+  });
+
+  it('emits a fish function', () => {
+    const out = renderShellInit('fish');
+    expect(out).toContain('function aimux');
+    expect(out).toContain('--export --shell fish');
+    expect(out).toContain('command aimux $argv');
+  });
+});

--- a/src/core/shellSwitch.test.ts
+++ b/src/core/shellSwitch.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { detectShell, parseShell, renderShellExports, renderShellInit } from './shellSwitch.js';
 
 describe('detectShell', () => {
@@ -61,6 +62,31 @@ describe('renderShellExports', () => {
     expect(out).toContain(`set -gx CLAUDE_CONFIG_DIR '/home/u/.aimux/profiles/work'`);
     expect(out).toContain(`set -e OLD_VAR`);
     expect(out).toContain(`set -gx AIMUX_PROFILE 'work'`);
+  });
+
+  // The output is eval'd, so injection-resistance of the quoting is the contract
+  // that matters most. Lock the exact rendered form for hostile values.
+  const EVIL = `a'b"c$(whoami)\`id\`\\d;e |f&`;
+
+  it('neutralizes shell metacharacters by single-quoting (posix)', () => {
+    const out = renderShellExports({ env: { EVIL }, profileName: 'p', shell: 'bash' });
+    // Only the single quote is escaped (as '\''); $(), backticks, \, ;, |, & are
+    // literal inside single quotes — never interpolated or executed.
+    expect(out).toContain(`export EVIL='a'\\''b"c$(whoami)\`id\`\\d;e |f&'`);
+  });
+
+  it('neutralizes backslashes and quotes (fish)', () => {
+    const out = renderShellExports({ env: { EVIL }, profileName: 'p', shell: 'fish' });
+    // fish single quotes escape only \\ and \' .
+    expect(out).toContain(`set -gx EVIL 'a\\'b"c$(whoami)\`id\`\\\\d;e |f&'`);
+  });
+
+  it('round-trips a hostile value through a real bash eval (no injection)', () => {
+    const value = `${EVIL}\nsecond-line`;
+    const script = renderShellExports({ env: { EVIL: value }, profileName: 'p', shell: 'bash' });
+    const out = execFileSync('bash', ['-c', `${script}\nprintf %s "$EVIL"`], { encoding: 'utf-8' });
+    // eval reproduced the value byte-for-byte and $(whoami)/`id` did not execute.
+    expect(out).toBe(value);
   });
 });
 

--- a/src/core/shellSwitch.ts
+++ b/src/core/shellSwitch.ts
@@ -60,6 +60,9 @@ export interface RenderExportsOptions {
  */
 export function renderShellExports({ env, profileName, previousManaged, shell }: RenderExportsOptions): string {
   const keys = Object.keys(env);
+  // Invariant: every entry is a bare env-var name (no spaces) — cleanup re-parses
+  // `$AIMUX_MANAGED` by splitting on whitespace, so a spaced value would strand
+  // stale keys and leak the previous profile's credentials across a switch.
   const managed = [...keys, 'AIMUX_PROFILE'];
   const stale = (previousManaged ?? '')
     .split(/\s+/)

--- a/src/core/shellSwitch.ts
+++ b/src/core/shellSwitch.ts
@@ -1,0 +1,113 @@
+import type { AimuxConfig } from '../types/index.js';
+import { buildRunParams } from './run.js';
+
+export type SupportedShell = 'bash' | 'zsh' | 'fish';
+
+/**
+ * Detect the user's shell from `$SHELL`, falling back to bash. Only the basename
+ * is inspected so `/usr/local/bin/zsh` resolves to `zsh`.
+ */
+export function detectShell(shellPath: string | undefined): SupportedShell {
+  const name = (shellPath ?? '').split('/').pop() ?? '';
+  if (name.includes('fish')) return 'fish';
+  if (name.includes('zsh')) return 'zsh';
+  return 'bash';
+}
+
+/**
+ * Resolve an explicit `--shell` value, or fall back to {@link detectShell}.
+ * Throws on an unsupported value so a typo fails loudly instead of silently
+ * emitting POSIX syntax into a shell that can't run it.
+ */
+export function parseShell(value: string | undefined, shellPath: string | undefined): SupportedShell {
+  if (!value) return detectShell(shellPath);
+  if (value === 'bash' || value === 'zsh' || value === 'fish') return value;
+  throw new Error(`Unsupported --shell '${value}'. Use bash, zsh, or fish.`);
+}
+
+/**
+ * Resolve the env var map that "activating" a profile injects into a shell.
+ * Reuses {@link buildRunParams} so the switch path stays byte-identical to what
+ * `aimux run` would export — adapter decides CLAUDE_CONFIG_DIR vs CODEX_HOME,
+ * plus any profile `.env` (ANTHROPIC_BASE_URL, tokens, model overrides).
+ */
+export function buildSwitchEnv(config: AimuxConfig, profileName: string): Record<string, string> {
+  return buildRunParams(config, profileName).env;
+}
+
+/** Single-quote a value for POSIX shells, escaping embedded single quotes. */
+function posixQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Single-quote a value for fish, escaping backslashes then single quotes. */
+function fishQuote(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, `\\'`)}'`;
+}
+
+export interface RenderExportsOptions {
+  env: Record<string, string>;
+  profileName: string;
+  /** Keys aimux set on the previous `use` (from `$AIMUX_MANAGED`), unset first. */
+  previousManaged?: string;
+  shell: SupportedShell;
+}
+
+/**
+ * Render the shell script that `eval`'d into the current shell activates a
+ * profile: unset the previously-managed keys, export the new ones, and record
+ * the active profile + managed key list so the next switch can clean up.
+ */
+export function renderShellExports({ env, profileName, previousManaged, shell }: RenderExportsOptions): string {
+  const keys = Object.keys(env);
+  const managed = [...keys, 'AIMUX_PROFILE'];
+  const stale = (previousManaged ?? '')
+    .split(/\s+/)
+    .filter((k) => k && !managed.includes(k));
+
+  const lines: string[] = [];
+  if (shell === 'fish') {
+    for (const key of stale) lines.push(`set -e ${key}`);
+    for (const key of keys) lines.push(`set -gx ${key} ${fishQuote(env[key])}`);
+    lines.push(`set -gx AIMUX_PROFILE ${fishQuote(profileName)}`);
+    lines.push(`set -gx AIMUX_MANAGED ${fishQuote(managed.join(' '))}`);
+  } else {
+    if (stale.length > 0) lines.push(`unset ${stale.join(' ')}`);
+    for (const key of keys) lines.push(`export ${key}=${posixQuote(env[key])}`);
+    lines.push(`export AIMUX_PROFILE=${posixQuote(profileName)}`);
+    lines.push(`export AIMUX_MANAGED=${posixQuote(managed.join(' '))}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Render the shell snippet for the user's rc file. It wraps the real binary so
+ * `aimux use <profile>` evaluates the exports in the current shell, while every
+ * other subcommand passes straight through.
+ */
+export function renderShellInit(shell: SupportedShell): string {
+  if (shell === 'fish') {
+    return [
+      'function aimux',
+      '    if test "$argv[1]" = "use"',
+      '        eval (command aimux use $argv[2..-1] --export --shell fish | string collect)',
+      '    else',
+      '        command aimux $argv',
+      '    end',
+      'end',
+    ].join('\n');
+  }
+  // bash / zsh share POSIX function syntax.
+  return [
+    'aimux() {',
+    '  if [ "$1" = "use" ]; then',
+    '    shift',
+    '    local _aimux_out',
+    '    _aimux_out="$(command aimux use "$@" --export)" || return $?',
+    '    eval "$_aimux_out"',
+    '  else',
+    '    command aimux "$@"',
+    '  fi',
+    '}',
+  ].join('\n');
+}


### PR DESCRIPTION
## Summary

Adds `aimux use` — activate a profile in the current shell so plain `claude` / `codex` run under it, the `nvm use` / `pyenv shell` model. This complements per-launch `aimux run` for people who want to set a profile once and keep using the native CLI.

Enable once:

```bash
eval "$(aimux shell-init)"   # add to ~/.zshrc / ~/.bashrc / fish config
```

Then:

```bash
aimux use work     # activate 'work' in this shell (persistent until you switch)
claude             # runs under 'work' — no `aimux run` needed
codex              # same; the CLI adapter sets CODEX_HOME
aimux use api      # switch — stale ANTHROPIC_*/tokens from the previous profile are unset
aimux use          # no name -> interactive picker
```

## Design notes

- Reuses `buildRunParams` so the activated env is byte-identical to what `aimux run` would inject. The CLI adapter decides `CLAUDE_CONFIG_DIR` vs `CODEX_HOME`, so this stays CLI-agnostic and fits the multi-CLI direction — no claude-specific branching.
- Per-shell only. It exports env into the current shell and never writes global state, so different terminals can hold different active profiles at once — preserving the "any profile, any terminal" model from the design doc.
- Clean switching: each `use` records the keys it set in `$AIMUX_MANAGED`; the next `use` unsets the stale ones first, so a subscription profile never inherits the previous profile's endpoint/token.
- `--export` keeps stdout to shell code only (it gets `eval`'d); all human output (confirmation, auto-sync, warnings, and the picker) goes to stderr.

## In-use indicator

`aimux status` / `profile list` mark the profile activated in the current shell — an `Active here:` line plus a row marker, read from `$AIMUX_PROFILE` and ignored when stale.

## Included fix

The no-arg `aimux use` opens the interactive `ProfilePicker`, which had a latent bug: its Enter handler set the choice but never called `exit()`, so `render().waitUntilExit()` never resolved and the picker hung on select. Fixed by calling `exit()` after selection. This is the same picker `aimux run` uses, so it fixes the no-arg `run` picker too.

## Tests

New `src/core/shellSwitch.test.ts` covers `detectShell`, `parseShell`, export rendering (posix + fish, stale-var unset, quote escaping), and the shell-init wrapper. Full suite: 262 passing.

## Notes for review

- `bash` / `zsh` / `fish` supported; `--shell` validates and errors on anything else.
- README "Switch your shell to a profile" section and CHANGELOG added; version bumped to 0.18.0.
