### PR TITLE
feat(session): pass reasoning effort through to the CLI as --effort

### DIFF
--- a/src/core/liveSession.test.ts
+++ b/src/core/liveSession.test.ts
@@ -73,6 +73,17 @@ describe('buildSessionArgs', () => {
     expect(args.some((a) => a.startsWith('--allowedTools'))).toBe(false);
   });
 
+  it('passes the reasoning effort level through as --effort', () => {
+    const { args } = buildSessionArgs(makeConfig(), 'work', { sessionId: 's', effort: 'xhigh' }, false);
+    expect(args).toContain('--effort');
+    expect(args[args.indexOf('--effort') + 1]).toBe('xhigh');
+  });
+
+  it('omits --effort when no effort is set', () => {
+    const { args } = buildSessionArgs(makeConfig(), 'work', { sessionId: 's' }, false);
+    expect(args).not.toContain('--effort');
+  });
+
   it('carries the profile account (CLAUDE_CONFIG_DIR), model, and spine task id', () => {
     const { env, args } = buildSessionArgs(makeConfig(), 'work', { sessionId: 's', taskId: 't-1' }, false);
     expect(env.CLAUDE_CONFIG_DIR).toBe('/home/user/.aimux/profiles/work');

--- a/src/core/liveSession.ts
+++ b/src/core/liveSession.ts
@@ -26,6 +26,10 @@ const DEFAULT_REPLY_TIMEOUT_MS = 10 * 60_000;
 export interface OpenSessionOptions {
   /** Model for THIS session (a session's model is fixed at spawn). */
   model?: string;
+  /** Reasoning effort for THIS session (→ `--effort <level>`), e.g. 'low' |
+   *  'medium' | 'high' | 'xhigh' | 'max'. aimux only knows the flag; the caller
+   *  owns the level. Omit to use the CLI's default. */
+  effort?: string;
   /** Stable id: created with `--session-id`, recovered with `--resume`. */
   sessionId: string;
   /** The session already exists in Claude (e.g. recovering after a host restart),
@@ -101,6 +105,7 @@ export function buildSessionArgs(
   const extra: string[] = [...STREAM_FLAGS];
   if (opts.settingsPath) extra.push('--settings', opts.settingsPath);
   if (opts.mcpConfigPath) extra.push('--mcp-config', opts.mcpConfigPath);
+  if (opts.effort) extra.push('--effort', opts.effort);
   if (opts.bypassPermissions) extra.push('--dangerously-skip-permissions');
   else if (opts.allowedTools && opts.allowedTools.length) extra.push(`--allowedTools=${opts.allowedTools.join(',')}`);
   // Session lifecycle: create with --session-id, recover with --resume.


### PR DESCRIPTION
OpenSessionOptions gains an optional `effort` level (low|medium|high|xhigh| max); buildSessionArgs appends `--effort <level>` when set. aimux only knows the flag — the caller owns the level. Enables a host to run a heavier- reasoning session per task (e.g. Loom's ultracode mode) without every session paying for it. Omitted → the CLI's default, so existing callers are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context)