### PR TITLE
fix(session): reply watchdog is an inactivity timeout, not a turn cap

### DIFF
--- a/src/core/liveSession.test.ts
+++ b/src/core/liveSession.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { buildSessionArgs, openSession, type SessionEvent } from './liveSession.js';
 import type { AimuxConfig } from '../types/index.js';
@@ -152,6 +152,24 @@ describe('openSession', () => {
     const r = await s.send('hang'); // no result emitted → watchdog fires
     expect(r.text).toContain('did not respond within the time limit');
     expect(procs[0].killed).toBe(true);
+  });
+
+  it('the watchdog resets on streamed activity — a long but ACTIVE turn is not killed', async () => {
+    vi.useFakeTimers();
+    try {
+      const { procs, spawnFn } = spy();
+      const s = openSession(makeConfig(), 'work', { sessionId: 'sid', spawnFn, replyTimeoutMs: 1000 });
+      const p = s.send('big implementation');
+      vi.advanceTimersByTime(900); // almost the cap…
+      procs[0].line({ type: 'assistant', message: { content: [{ type: 'text', text: 'still working' }] } }); // …activity re-arms it
+      vi.advanceTimersByTime(900); // 1800ms total, but only 900ms since the reset → survives
+      procs[0].line({ type: 'result', result: 'done' });
+      const r = await p;
+      expect(r.text).toBe('done'); // completed, NOT the timeout marker
+      expect(procs[0].killed).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('a session opened with resume:true recovers on the FIRST send (host-restart)', async () => {

--- a/src/core/liveSession.ts
+++ b/src/core/liveSession.ts
@@ -164,6 +164,9 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
   let buf = '';
   let pending: ((r: TurnResult) => void) | null = null;
   let curEvent: ((e: SessionEvent) => void) | undefined;
+  // Reset the reply watchdog on streamed activity, so it's an INACTIVITY timeout
+  // (a long-but-active turn survives) rather than a hard cap on turn duration.
+  let resetWatchdog: (() => void) | null = null;
   let totalCost = 0;
   const denialSet: string[] = [];
   // First send creates the session (--session-id); afterwards it recovers (--resume).
@@ -187,6 +190,7 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
       let ev: { type?: string; result?: string; total_cost_usd?: number; permission_denials?: unknown[]; message?: { content?: unknown } };
       try { ev = JSON.parse(line); } catch { continue; }
       if (ev.type === 'assistant') {
+        resetWatchdog?.(); // the agent is working — keep the watchdog from firing
         const s = summarizeAssistant(ev.message?.content);
         if (s) curEvent?.({ kind: 'assistant', text: s, raw: ev });
       } else if (ev.type === 'result') {
@@ -228,13 +232,19 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
       curEvent = onEvent;
       return new Promise<TurnResult>((resolve) => {
         let timer: ReturnType<typeof setTimeout>;
-        pending = (r: TurnResult) => { clearTimeout(timer); resolve(r); };
-        timer = setTimeout(() => {
+        const arm = (): ReturnType<typeof setTimeout> => setTimeout(() => {
           pending = null;
+          resetWatchdog = null;
           try { child.kill(); } catch { /* best-effort */ }
           proc = null;
           resolve({ text: '⏱ The agent did not respond within the time limit — the session was stopped. Re-run the stage or switch the subscription.', costUsd: 0, denials: [] });
         }, replyTimeout);
+        timer = arm();
+        // INACTIVITY timeout: every streamed event re-arms it (see onData), so a
+        // long but actively-working turn (a big implementation) is not killed —
+        // only a genuinely silent/stuck one is.
+        resetWatchdog = () => { clearTimeout(timer); timer = arm(); };
+        pending = (r: TurnResult) => { clearTimeout(timer); resetWatchdog = null; resolve(r); };
         child.stdin?.write(userMessage(text));
       });
     },


### PR DESCRIPTION
## What
The reply watchdog armed once per `send()` and only cleared on the turn's `result`. So a turn that ran longer than `replyTimeoutMs` (default 10 min) got killed **even while the agent was actively streaming** — a long implementation died with "did not respond within the time limit" mid-work.

## Fix
Re-arm the watchdog on every streamed `assistant` event (`onData`), so it's an **inactivity** timeout: it fires only on genuine silence, while a long-but-active turn keeps going.

## Tests
- new: a long ACTIVE turn (activity re-arms the watchdog past the original cap) is **not** killed and completes.
- existing: a silent/stuck turn still times out and the process is killed.
- full suite green (268).

https://claude.ai/code/session_012GujqUM9Rzsu9dmhee8fQy