### PR TITLE
feat: strengthen multi-CLI — codex usage/pricing, safe profile remove, handoff precision (0.20.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.20.0] - 2026-06-28
+
+### Added
+- **`aimux usage` now includes codex sessions.** Usage scanned only Claude
+  transcripts, so codex profiles showed zero tokens and `$0` — a silently
+  incomplete report. It now also reads codex session rollouts (final cumulative
+  `token_count`, with `cached_input_tokens` split into the cache-read bucket) and
+  attributes them to a profile via the same history → `unknown` fallback as Claude.
+- **Pricing for OpenAI / codex (gpt-5 family).** Added list-price estimates for
+  `gpt-5.3-codex`, `gpt-5-codex`, `gpt-5.5`, `gpt-5.4`, `gpt-5` (plus family
+  prefixes) so codex turns are no longer costed at `$0`. Estimates only, like the
+  existing Claude/provider prices.
+
+### Fixed
+- **`aimux profile remove` confirms before deleting.** It ran `rm -rf` on the
+  profile's directory (credentials included) with no confirmation; combined with
+  prefix-matched names, a typo could wipe the wrong profile. It now prompts `[y/N]`
+  on a TTY (echoing the resolved name + full path). **Behavior change:** in a
+  non-interactive shell it refuses to delete unless `-y/--yes` is passed (scripts
+  must opt in). `--keep-dir` still removes the profile without touching disk.
+- **Handoff locates the codex transcript by exact session id** (the trailing
+  `-<uuid>.jsonl`) instead of a substring match a sibling file could win, and only
+  trusts the generated summary when the headless summarizer exits `0`.
+
 ## [0.19.1] - 2026-06-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ never changes global state. `aimux run` still works for one-off launches.
 | `aimux init` | Auto-detect Claude dirs, create config, migrate profiles |
 | `aimux init --source <path>` | Initialize with explicit source directory |
 | `aimux status` | TUI dashboard — profiles, auth, auto-mode posture, symlink health |
-| `aimux usage` | Show token usage by profile from Claude transcript metadata |
+| `aimux usage` | Show token usage by profile (Claude transcripts + codex rollouts) |
 | `aimux usage --profile work --since 24h` | Show usage for one profile over a recent window |
 | `aimux run [profile]` | Launch AI CLI with correct env and model |
 | `aimux run` | Interactive picker — history pre-selects last used profile |
@@ -256,8 +256,8 @@ model names drift — update with `aimux profile update <name> -e ANTHROPIC_MODE
 
 For anything else (local models via Ollama/LM Studio, a proxy, Bedrock/Vertex), use the
 generic `aimux profile add <name> --api` and point `ANTHROPIC_BASE_URL` at it (see below).
-Costs shown by `aimux usage` are estimated against claude pricing and will be off for
-non-claude models.
+Costs shown by `aimux usage` are list-price estimates (Claude, codex/gpt-5, and the
+Anthropic-compatible providers) and will drift as prices change.
 
 ## Per-profile environment variables
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -13,7 +13,7 @@ import {
   launchProfile, getLastProfile, recordHistory, getProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
-  loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson,
+  loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson, confirm,
   parseShell, buildSwitchEnv, renderShellExports, renderShellInit,
 } from './core/index.js';
 
@@ -682,17 +682,30 @@ program
     new Command('remove')
       .argument('<name>', 'Profile name')
       .option('--keep-dir', 'Keep profile directory on disk')
+      .option('-y, --yes', 'Skip the deletion confirmation prompt')
       .description('Remove a profile')
-      .action((name: string, options: { keepDir?: boolean }) => {
+      .action(async (name: string, options: { keepDir?: boolean; yes?: boolean }) => {
         try {
           let config = requireConfig();
           const resolved = resolveProfile(config, name);
-          const profile = config.profiles[resolved];
-          const profilePath = profile.path;
+          const fullPath = expandHome(config.profiles[resolved].path);
+
+          // Deleting the directory wipes that profile's credentials and is
+          // irreversible; with prefix-matched names a typo could target the wrong
+          // profile. Confirm before destroying anything, and never delete silently
+          // in a non-interactive shell.
+          if (!options.keepDir && !options.yes) {
+            if (!process.stdin.isTTY) {
+              console.error(`Refusing to delete '${resolved}' and its directory (${fullPath}) without confirmation. Re-run with --yes, or --keep-dir to keep the files.`);
+              process.exit(1);
+            }
+            const ok = await confirm(`Delete profile '${resolved}' and its directory ${fullPath}? [y/N] `);
+            if (!ok) { console.log('Aborted — nothing was removed.'); return; }
+          }
+
           config = removeProfile(config, resolved);
           saveConfig(config);
           if (!options.keepDir) {
-            const fullPath = expandHome(profilePath);
             rmSync(fullPath, { recursive: true, force: true });
             console.log(`✓ Profile '${resolved}' removed (directory deleted)`);
           } else {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -120,7 +120,7 @@ program
 
 program
   .command('usage')
-  .description('Show token usage by profile from Claude transcript metadata')
+  .description('Show token usage by profile (Claude transcripts + codex rollouts)')
   .option('-p, --profile <profile>', 'Only show one profile (supports prefix matching)')
   .option('--since <duration>', 'Only include usage since duration: 24h, 7d, 4w', '7d')
   .option('--all', 'Include all known transcript usage')
@@ -134,7 +134,7 @@ program
       if (!options.all) {
         console.log(`\nWindow: ${options.since}`);
       }
-      console.log('Source: shared projects/*.jsonl transcript usage metadata; duplicate requestIds counted once.');
+      console.log('Source: Claude projects/*.jsonl transcripts + codex session rollouts; duplicate Claude requestIds counted once. $ are list-price estimates.');
       if (summaries.some((s) => s.profile === 'unknown')) {
         console.log('Note: unknown means aimux could not map a transcript session to a profile.');
       }

--- a/src/core/apiProfile.test.ts
+++ b/src/core/apiProfile.test.ts
@@ -2,8 +2,16 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions } from './apiProfile.js';
+import { writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, isAffirmative } from './apiProfile.js';
 import { parseDotenv } from './run.js';
+
+describe('isAffirmative', () => {
+  it('is true only for an explicit yes (any case), false for everything else', () => {
+    for (const yes of ['y', 'Y', 'yes', 'YES', 'Yes', ' y ', 'yes\n']) expect(isAffirmative(yes)).toBe(true);
+    // Safety: a destructive confirm must NOT treat empty/garbage/"no" as consent.
+    for (const no of ['', 'n', 'N', 'no', 'nope', 'sure', 'ya', 'yep', '1', 'true']) expect(isAffirmative(no)).toBe(false);
+  });
+});
 
 describe('writeProfileDotEnv', () => {
   let dir: string;

--- a/src/core/apiProfile.ts
+++ b/src/core/apiProfile.ts
@@ -199,6 +199,21 @@ class StdinLineReader {
   }
 }
 
+/** Yes/no parse for confirmations: only an explicit `y`/`yes` (any case) consents. */
+export function isAffirmative(answer: string): boolean {
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+/** Ask a `[y/N]` question on the shared stdin reader; false unless the answer is affirmative. */
+export async function confirm(question: string): Promise<boolean> {
+  const reader = new StdinLineReader();
+  try {
+    return isAffirmative(await reader.question(question));
+  } finally {
+    reader.close();
+  }
+}
+
 /**
  * Interactively collect 3rd-party API endpoint credentials. Returns the env
  * var map to persist to the profile's `.env`. The auth token is read with no

--- a/src/core/codexSessionScanner.ts
+++ b/src/core/codexSessionScanner.ts
@@ -49,7 +49,7 @@ function isCodexPreamble(text: string): boolean {
   );
 }
 
-function listRolloutFiles(sessionsRoot: string): string[] {
+export function listRolloutFiles(sessionsRoot: string): string[] {
   const out: string[] = [];
   const stack = [sessionsRoot];
   while (stack.length) {

--- a/src/core/codexUsage.test.ts
+++ b/src/core/codexUsage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import type { AimuxConfig } from '../types/index.js';
+import { setAimuxDir } from './paths.js';
+import { summarizeUsage } from './usage.js';
+
+// A codex rollout: { timestamp, type, payload }. session_meta carries the id,
+// turn_context the model, and event_msg/token_count the cumulative usage.
+const UUID = '019c6198-5b6e-7671-b79c-2e3c96f32d95';
+
+function rolloutLines(model: string, total: Record<string, number>): string {
+  return [
+    { timestamp: '2026-06-28T10:00:00.000Z', type: 'session_meta', payload: { id: UUID, cwd: '/tmp/proj' } },
+    { timestamp: '2026-06-28T10:00:01.000Z', type: 'turn_context', payload: { cwd: '/tmp/proj', model } },
+    { timestamp: '2026-06-28T10:00:02.000Z', type: 'event_msg', payload: { type: 'token_count', info: null } },
+    { timestamp: '2026-06-28T10:00:03.000Z', type: 'event_msg', payload: { type: 'token_count', info: { total_token_usage: total, last_token_usage: total } } },
+  ].map((l) => JSON.stringify(l)).join('\n');
+}
+
+describe('codex usage in summarizeUsage', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'aimux-codex-usage-'));
+    setAimuxDir(join(dir, 'aimux')); // isolate history/profile-map lookups
+    const rolloutDir = join(dir, 'codex', 'sessions', '2026', '06', '28');
+    mkdirSync(rolloutDir, { recursive: true });
+    writeFileSync(
+      join(rolloutDir, `rollout-2026-06-28T10-00-00-${UUID}.jsonl`),
+      rolloutLines('gpt-5-codex', {
+        input_tokens: 10000, cached_input_tokens: 4000, output_tokens: 2000,
+        reasoning_output_tokens: 500, total_tokens: 12000,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    setAimuxDir('');
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function config(): AimuxConfig {
+    return {
+      version: 1,
+      shared_source: join(dir, 'claude-empty'),
+      shared_sources: { codex: join(dir, 'codex') },
+      profiles: { cx: { cli: 'codex', path: join(dir, 'profiles', 'cx') } },
+      private: [],
+    };
+  }
+
+  it('maps codex token_count into the usage buckets (cached split out) and prices it', () => {
+    const summaries = summarizeUsage(config());
+    // Unattributed (not in history) → lands under the 'unknown' profile, like claude.
+    const u = summaries.find((s) => s.profile === 'unknown');
+    expect(u).toBeDefined();
+    expect(u!.cacheReadInputTokens).toBe(4000);     // cached_input_tokens
+    expect(u!.inputTokens).toBe(6000);              // input_tokens - cached
+    expect(u!.cacheCreationInputTokens).toBe(0);    // codex reports no cache writes
+    expect(u!.outputTokens).toBe(2000);
+    expect(u!.estimatedCostUsd).toBeGreaterThan(0); // gpt-5-codex is priced, not $0
+  });
+
+  it('does not scan codex when no codex profile is configured', () => {
+    const claudeOnly: AimuxConfig = { ...config(), profiles: { main: { cli: 'claude', path: join(dir, 'x'), is_source: true } } };
+    const summaries = summarizeUsage(claudeOnly);
+    expect(summaries.find((s) => s.profile === 'unknown')).toBeUndefined();
+  });
+});

--- a/src/core/codexUsage.test.ts
+++ b/src/core/codexUsage.test.ts
@@ -63,6 +63,23 @@ describe('codex usage in summarizeUsage', () => {
     expect(u!.estimatedCostUsd).toBeGreaterThan(0); // gpt-5-codex is priced, not $0
   });
 
+  it('counts a session once (max cumulative) when it spans multiple rollout files', () => {
+    // codex resume can write a second rollout for the same session id; each carries
+    // its own cumulative total. Summing them would double-count — keep the largest.
+    const day = join(dir, 'codex', 'sessions', '2026', '06', '28');
+    writeFileSync(
+      join(day, `rollout-2026-06-28T12-00-00-${UUID}.jsonl`),
+      rolloutLines('gpt-5-codex', {
+        input_tokens: 25000, cached_input_tokens: 10000, output_tokens: 5000,
+        reasoning_output_tokens: 1000, total_tokens: 30000,
+      }),
+    );
+    const u = summarizeUsage(config()).find((s) => s.profile === 'unknown')!;
+    // Larger file wins; NOT the sum (2000 + 5000 = 7000) of both files.
+    expect(u.outputTokens).toBe(5000);
+    expect(u.inputTokens).toBe(15000); // 25000 - 10000, from the larger rollout
+  });
+
   it('does not scan codex when no codex profile is configured', () => {
     const claudeOnly: AimuxConfig = { ...config(), profiles: { main: { cli: 'claude', path: join(dir, 'x'), is_source: true } } };
     const summaries = summarizeUsage(claudeOnly);

--- a/src/core/handoff.test.ts
+++ b/src/core/handoff.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-import { buildHandoffPrompt, buildSummarizePrompt, handoffSession, type HandoffDeps } from './handoff.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { buildHandoffPrompt, buildSummarizePrompt, handoffSession, readTranscript, type HandoffDeps } from './handoff.js';
 import type { AimuxConfig } from '../types/index.js';
 import type { UnifiedSession } from './unifiedSessions.js';
 
@@ -37,6 +40,29 @@ describe('prompt builders', () => {
     expect(out).toContain('--- TRANSCRIPT ---');
     expect(out).toContain('TRANSCRIPT_BODY');
     expect(out).toContain('immediate next step');
+  });
+});
+
+describe('readTranscript (codex)', () => {
+  let dir: string;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); });
+
+  const ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+  function codexConfig(): AimuxConfig {
+    return { version: 1, shared_source: '/x', shared_sources: { codex: dir }, profiles: {}, private: [] } as AimuxConfig;
+  }
+
+  it('matches the rollout by exact session id, not a substring', () => {
+    dir = mkdtempSync(join(tmpdir(), 'aimux-handoff-codex-'));
+    const day = join(dir, 'sessions', '2026', '06', '28');
+    mkdirSync(day, { recursive: true });
+    // Decoy: filename CONTAINS the id but isn't the session's rollout (extra suffix).
+    writeFileSync(join(day, `rollout-2026-06-28T10-00-00-${ID}-decoy.jsonl`), 'DECOY');
+    writeFileSync(join(day, `rollout-2026-06-28T11-00-00-${ID}.jsonl`), 'REAL');
+
+    const text = readTranscript(codexConfig(), session({ cli: 'codex', sessionId: ID }));
+    expect(text).toBe('REAL');
   });
 });
 

--- a/src/core/handoff.ts
+++ b/src/core/handoff.ts
@@ -57,7 +57,9 @@ export function readTranscript(config: AimuxConfig, session: UnifiedSession): st
           const p = join(dir, name);
           const st = statSync(p);
           if (st.isDirectory()) stack.push(p);
-          else if (name.includes(session.sessionId) && name.endsWith('.jsonl')) {
+          // The session id is the rollout's trailing uuid (rollout-<ts>-<uuid>.jsonl);
+          // match it exactly so a sibling whose name merely contains the id can't win.
+          else if (name.startsWith('rollout-') && name.endsWith(`-${session.sessionId}.jsonl`)) {
             return tail(readFileSync(p, 'utf-8'), TRANSCRIPT_CHAR_BUDGET);
           }
         }
@@ -98,7 +100,10 @@ const defaultDeps: HandoffDeps = {
       // codex: read the clean final message from a temp file (stdout is noisy).
       const outFile = join(tmpdir(), `aimux-handoff-${process.pid}-${randomBytes(4).toString('hex')}.txt`);
       try {
-        await runProfileHeadless(config, viaProfile, { extraArgs: adapter.headlessArgs(prompt, outFile) });
+        const res = await runProfileHeadless(config, viaProfile, { extraArgs: adapter.headlessArgs(prompt, outFile) });
+        // A non-zero exit means the summarizer errored; any partial output it left
+        // is untrustworthy — fail loudly rather than hand off a bad summary.
+        if (res.exitCode !== 0) throw new Error(`Summarizer (${viaProfile}) exited with code ${res.exitCode}`);
         return existsSync(outFile) ? readFileSync(outFile, 'utf-8').trim() : '';
       } finally {
         try {
@@ -109,6 +114,7 @@ const defaultDeps: HandoffDeps = {
       }
     }
     const res = await runProfileHeadless(config, viaProfile, { extraArgs: adapter.headlessArgs(prompt) });
+    if (res.exitCode !== 0) throw new Error(`Summarizer (${viaProfile}) exited with code ${res.exitCode}`);
     return res.stdout.trim();
   },
   launch(config, toProfile, seedPrompt) {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -65,6 +65,8 @@ export {
   checkDotenvPermissions,
   seedApiClaudeJson,
   API_MODEL_DEFAULTS,
+  isAffirmative,
+  confirm,
 } from './apiProfile.js';
 export type { ProviderPreset } from './apiProfile.js';
 

--- a/src/core/pricing.test.ts
+++ b/src/core/pricing.test.ts
@@ -28,6 +28,17 @@ describe('resolvePricing', () => {
   it('returns null for an unknown model', () => {
     expect(resolvePricing('totally-made-up-model')).toBeNull();
   });
+
+  it('prices codex / gpt-5 models so codex usage is not silently $0', () => {
+    expect(resolvePricing('gpt-5-codex')?.input).toBeGreaterThan(0);
+    expect(resolvePricing('gpt-5.3-codex')?.input).toBeGreaterThan(0);
+    expect(resolvePricing('gpt-5')?.input).toBeGreaterThan(0);
+  });
+
+  it('matches a future gpt-5.x codex variant by prefix', () => {
+    // An unseen codex point-release still resolves (to the gpt-5 family) rather than null.
+    expect(resolvePricing('gpt-5.9-codex-20991231')).not.toBeNull();
+  });
 });
 
 describe('hasPricing', () => {

--- a/src/core/pricing.ts
+++ b/src/core/pricing.ts
@@ -38,6 +38,14 @@ export const MODEL_PRICING: Record<string, ModelPricing> = {
   'deepseek-chat': thirdParty(0.27, 1.1),
   'deepseek-reasoner': thirdParty(0.55, 2.19),
   'qwen-max': thirdParty(1.6, 6.4),
+  // OpenAI / codex CLI (list prices, same cache shape as other OpenAI-compatible
+  // endpoints). Subscription codex isn't billed per token; this estimates what the
+  // same tokens would cost at API list price, mirroring how Claude profiles are costed.
+  'gpt-5.3-codex': thirdParty(1.75, 14),
+  'gpt-5-codex': thirdParty(1.25, 10),
+  'gpt-5.5': thirdParty(5, 30),
+  'gpt-5.4': thirdParty(2.5, 15),
+  'gpt-5': thirdParty(1.25, 10),
 };
 
 /** Family fallbacks, longest-prefix-first, for unseen patch/date variants. */
@@ -50,6 +58,12 @@ const FAMILY_PREFIXES: Array<[string, ModelPricing]> = [
   ['deepseek-reasoner', thirdParty(0.55, 2.19)],
   ['deepseek', thirdParty(0.27, 1.1)],
   ['qwen', thirdParty(1.6, 6.4)],
+  // Longest-first so a codex point-release wins over the bare gpt-5 family.
+  ['gpt-5.3-codex', thirdParty(1.75, 14)],
+  ['gpt-5-codex', thirdParty(1.25, 10)],
+  ['gpt-5.5', thirdParty(5, 30)],
+  ['gpt-5.4', thirdParty(2.5, 15)],
+  ['gpt-5', thirdParty(1.25, 10)],
 ];
 
 export function resolvePricing(model: string): ModelPricing | null {

--- a/src/core/usage.ts
+++ b/src/core/usage.ts
@@ -2,9 +2,11 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import type { AimuxConfig } from '../types/index.js';
 import { expandHome } from './paths.js';
+import { sourceFor } from './config.js';
 import { loadSessionHistory } from './sessionHistory.js';
 import { buildProfileSessionMap } from './profileSessionMap.js';
 import { parseSessionJsonl, quickFirstLineType } from './sessionScanner.js';
+import { listRolloutFiles } from './codexSessionScanner.js';
 import { estimateCost } from './pricing.js';
 
 export interface UsageTotals {
@@ -150,10 +152,21 @@ interface UsageRecord {
   usage: UsagePayload;
 }
 
-// Single scan of all transcripts → deduplicated per-request usage records. Shared by
+// All usage records across every configured CLI → deduplicated per-request. Shared by
 // summarizeUsage (group by profile) and usageBySession (group by session) so both stay
-// in sync and the scan/dedup logic lives in one place.
+// in sync. claude transcripts and codex rollouts live in different trees/formats, so each
+// CLI has its own collector; profile attribution (history → 'unknown' fallback) is shared.
 function collectUsageRecords(config: AimuxConfig, options: UsageOptions = {}): UsageRecord[] {
+  const records = collectClaudeUsageRecords(config, options);
+  if (Object.values(config.profiles).some((p) => p.cli === 'codex')) {
+    records.push(...collectCodexUsageRecords(config, options));
+  }
+  return records;
+}
+
+// claude: one deduplicated record per assistant request, scanned from the shared
+// projects/*.jsonl transcript tree.
+function collectClaudeUsageRecords(config: AimuxConfig, options: UsageOptions = {}): UsageRecord[] {
   const projectsRoot = join(expandHome(config.shared_source), 'projects');
   const records: UsageRecord[] = [];
   if (!existsSync(projectsRoot)) return records;
@@ -221,6 +234,85 @@ function collectUsageRecords(config: AimuxConfig, options: UsageOptions = {}): U
         records.push({ profile, sessionId, model: formatModel(line.message?.model), usage });
       }
     }
+  }
+
+  return records;
+}
+
+const MAX_ROLLOUT_BYTES = 256 * 1024 * 1024;
+
+// codex: one record per session from its rollout JSONL. codex emits cumulative
+// token_count events; the final total_token_usage is the session's lifetime total.
+// cached_input_tokens is a SUBSET of input_tokens, so split it into the cache-read
+// bucket; codex reports no separate cache-write tier.
+function collectCodexUsageRecords(config: AimuxConfig, options: UsageOptions = {}): UsageRecord[] {
+  const sessionsRoot = join(expandHome(sourceFor(config, 'codex')), 'sessions');
+  const records: UsageRecord[] = [];
+  if (!existsSync(sessionsRoot)) return records;
+
+  const history = loadSessionHistory();
+  const profileMap = buildProfileSessionMap(config);
+
+  for (const filePath of listRolloutFiles(sessionsRoot)) {
+    let stat;
+    try {
+      stat = statSync(filePath);
+    } catch {
+      continue;
+    }
+    if (options.sinceMs !== undefined && stat.mtimeMs < options.sinceMs) continue;
+    // A multi-hundred-MB rollout is pathological; reading it fully would spike
+    // memory (or exceed V8's string limit). Skip rather than risk an OOM.
+    if (stat.size > MAX_ROLLOUT_BYTES) continue;
+
+    let lines: string[];
+    try {
+      lines = readFileSync(filePath, 'utf-8').split('\n');
+    } catch {
+      continue;
+    }
+
+    let sessionId = '';
+    let model = '';
+    let total: Record<string, unknown> | null = null;
+    for (const raw of lines) {
+      if (!raw) continue;
+      let rec: { type?: string; payload?: Record<string, any> };
+      try {
+        rec = JSON.parse(raw);
+      } catch {
+        continue;
+      }
+      const payload = rec?.payload;
+      if (!payload) continue;
+      if (rec.type === 'session_meta') sessionId = payload.id ?? sessionId;
+      else if (rec.type === 'turn_context') model = payload.model ?? model;
+      else if (rec.type === 'event_msg' && payload.type === 'token_count' && payload.info?.total_token_usage) {
+        total = payload.info.total_token_usage; // last wins → session lifetime total
+      }
+    }
+
+    if (!sessionId) {
+      const m = /rollout-.*-([0-9a-fA-F-]{36})\.jsonl$/.exec(filePath);
+      if (!m) continue;
+      sessionId = m[1];
+    }
+    if (!total) continue;
+
+    const inputAll = numberValue(total.input_tokens);
+    const cached = numberValue(total.cached_input_tokens);
+    const usage: UsagePayload = {
+      input_tokens: Math.max(0, inputAll - cached),
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: cached,
+      output_tokens: numberValue(total.output_tokens),
+    };
+
+    const profile =
+      history.get(sessionId)?.profile ?? profileMap.get(sessionId)?.profile ?? 'unknown';
+    if (options.profile && profile !== options.profile) continue;
+
+    records.push({ profile, sessionId, model: model || 'unknown', usage });
   }
 
   return records;

--- a/src/core/usage.ts
+++ b/src/core/usage.ts
@@ -247,8 +247,10 @@ const MAX_ROLLOUT_BYTES = 256 * 1024 * 1024;
 // bucket; codex reports no separate cache-write tier.
 function collectCodexUsageRecords(config: AimuxConfig, options: UsageOptions = {}): UsageRecord[] {
   const sessionsRoot = join(expandHome(sourceFor(config, 'codex')), 'sessions');
-  const records: UsageRecord[] = [];
-  if (!existsSync(sessionsRoot)) return records;
+  // Dedup by sessionId: codex resume can write a second rollout for the same session,
+  // each carrying its own cumulative total. Keep the largest so it isn't double-counted.
+  const bySession = new Map<string, { record: UsageRecord; cumulative: number }>();
+  if (!existsSync(sessionsRoot)) return [];
 
   const history = loadSessionHistory();
   const profileMap = buildProfileSessionMap(config);
@@ -300,22 +302,30 @@ function collectCodexUsageRecords(config: AimuxConfig, options: UsageOptions = {
     if (!total) continue;
 
     const inputAll = numberValue(total.input_tokens);
-    const cached = numberValue(total.cached_input_tokens);
+    const cached = numberValue(total.cached_input_tokens); // a SUBSET of input_tokens
+    const output = numberValue(total.output_tokens);
     const usage: UsagePayload = {
       input_tokens: Math.max(0, inputAll - cached),
       cache_creation_input_tokens: 0,
       cache_read_input_tokens: cached,
-      output_tokens: numberValue(total.output_tokens),
+      output_tokens: output,
     };
 
     const profile =
       history.get(sessionId)?.profile ?? profileMap.get(sessionId)?.profile ?? 'unknown';
     if (options.profile && profile !== options.profile) continue;
 
-    records.push({ profile, sessionId, model: model || 'unknown', usage });
+    // Default to the codex flagship when the rollout carried no model, so a session
+    // with usage is never silently priced at $0 — the bug this collector fixes.
+    const record: UsageRecord = { profile, sessionId, model: model || 'gpt-5-codex', usage };
+    const cumulative = numberValue(total.total_tokens) || inputAll + output;
+    const existing = bySession.get(sessionId);
+    if (!existing || cumulative > existing.cumulative) {
+      bySession.set(sessionId, { record, cumulative });
+    }
   }
 
-  return records;
+  return [...bySession.values()].map((e) => e.record);
 }
 
 export function summarizeUsage(config: AimuxConfig, options: UsageOptions = {}): ProfileUsageSummary[] {


### PR DESCRIPTION
Strengthens aimux from the audit of unfinished/weak spots. The theme: the multi-CLI abstraction stopped at the run-path, so usage/pricing silently assumed Claude. Plus one destructive-op footgun. Backward-compatible except one documented safety change. **274 tests pass; tsc clean.** Verified on real data.

## What's in it (5 commits, each TDD'd)

1. **`fix(profile)`: confirm before deleting a profile's directory.** `profile remove` ran `rm -rf` on the profile dir (credentials included) with no confirmation — with prefix-matched names a typo could wipe the wrong profile. Now prompts `[y/N]` on a TTY (echoing the resolved name + full path). **Behavior change:** non-interactive shells refuse to delete unless `-y/--yes` (scripts opt in). `--keep-dir` unchanged.

2. **`feat(pricing)`: OpenAI/codex (gpt-5 family) prices.** pricing knew only Claude + Anthropic-compatible providers, so codex cost was always `$0`. Added `gpt-5.3-codex`, `gpt-5-codex`, `gpt-5.5/5.4/5` (+ family prefixes, longest-first). Estimates only.

3. **`feat(usage)`: include codex sessions.** `aimux usage` scanned only Claude `projects/*.jsonl`, so codex profiles showed 0 tokens / `$0`. Added a codex collector (final cumulative `token_count`, `cached_input_tokens` → cache-read bucket) attributed via the same history → `unknown` fallback as Claude. Pathological multi-hundred-MB rollouts are skipped (OOM guard). **Verified on real data: +122M input / +7.8M output / ~\$869 that were previously invisible.**

4. **`fix(handoff)`: codex precision.** Located the codex transcript by `name.includes(sessionId)` (a substring a sibling could win) → now matches the trailing `-<uuid>.jsonl` exactly. Also only trusts the generated summary when the headless summarizer exits `0`.

5. **`chore(release)`: 0.20.0** — CHANGELOG + version + README accuracy.

## Not in scope (deliberate)
- **Gemini CLI adapter** — researched (gemini 0.38.2). It's feasible but NOT a codex-adapter copy: gemini's config-dir override is `GEMINI_CLI_HOME` which sets HOME and gemini appends `/.gemini` (breaks the "profile dir = config dir" model), and resume is by index/`latest`, not by session UUID (incompatible with aimux resume-by-id). Deserves its own designed PR.

## Compat
Additive except the `profile remove` non-interactive change (documented in CHANGELOG). No CLI command signature removed; `openSession`/run/use unchanged. claude behavior unchanged.