### PR TITLE
feat(gemini): add Gemini CLI as a third adapter (0.21.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.21.0] - 2026-06-29
+
+### Added
+- **Gemini CLI support (`--cli gemini`).** A third AI CLI alongside claude and codex.
+  `aimux profile add gem --cli gemini` creates an isolated Gemini profile that shares
+  knowledge (`GEMINI.md`, `skills`, `commands`, `extensions`, `memories`) from
+  `~/.gemini` while keeping auth, `settings.json`, and history private. `run` / `use`
+  launch `gemini` with the right `-m <model>` flag under an isolated config dir.
+  - Gemini has no direct config-dir override, so aimux sets `GEMINI_CLI_HOME` to the
+    profile's parent and makes the profile dir itself gemini's `.gemini` (a new optional
+    `CliAdapter.configPathFor`). claude/codex profile paths are unchanged.
+  - `aimux init` now also hints when `~/.gemini` is detected.
+  - Note: Gemini resumes by per-project index (`-r latest`), not by session id, so
+    cross-Gemini native resume is not wired into the session list yet.
+
 ## [0.20.0] - 2026-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -198,27 +198,33 @@ plugins from your main profile (or with `CLAUDE_CONFIG_DIR=~/.claude claude plug
 and every profile picks them up on its next run. A plugin installed from inside a
 profile is merged back into the shared source automatically.
 
-## Multiple AI CLIs (Codex)
+## Multiple AI CLIs (Codex, Gemini)
 
 aimux isn't claude-only. A profile's `cli` field selects which AI CLI it runs, so you
-can keep claude **and** Codex subscriptions side by side — same shared brain, isolated
-auth — and even hand a live conversation from one to the other when a limit hits.
+can keep claude, Codex, **and** Gemini subscriptions side by side — same shared brain,
+isolated auth — and even hand a live conversation from one to the other when a limit hits.
 
 ```bash
 aimux profile add codework --cli codex   # a Codex profile
+aimux profile add gem --cli gemini       # a Gemini profile (~/.gemini)
 aimux auth login codework                # runs `codex login` under an isolated CODEX_HOME
 aimux run codework                        # launches Codex with the right model flag
 aimux agents                              # claude + codex sessions in one view (CLI-badged)
 ```
 
 - **Isolation per CLI.** Each CLI gets its own config-dir env (`CLAUDE_CONFIG_DIR` /
-  `CODEX_HOME`), so subscriptions never collide.
+  `CODEX_HOME` / `GEMINI_CLI_HOME`), so subscriptions never collide.
 - **Per-CLI source-of-truth.** `shared_sources` maps each CLI to its source
   (`claude → ~/.claude`, `codex → ~/.codex`); the legacy `shared_source` stays as the
   claude alias.
 - **Per-CLI sharing.** claude shares everything except `private`; Codex shares a
   knowledge allowlist (`skills`, `rules`, `memories`) and keeps `auth.json` /
-  `config.toml` / `sessions/` private. (Codex plugin sharing is a planned follow-up.)
+  `config.toml` / `sessions/` private; Gemini shares `GEMINI.md` / `skills` / `commands`
+  / `extensions` / `memories` and keeps auth + `settings.json` + history private.
+- **Gemini specifics.** Gemini has no direct config-dir override, so aimux points
+  `GEMINI_CLI_HOME` at the profile's parent and the profile dir IS gemini's `.gemini`.
+  Gemini resumes by per-project index (`-r latest`), not by session id, so cross-Gemini
+  native resume isn't wired into the session list yet.
 - **claude is untouched.** Multi-CLI is strictly opt-in — without a non-claude profile
   nothing changes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.17.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-threads/aimux",
-      "version": "0.17.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -8,7 +8,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   loadConfig, saveConfig, addProfile, removeProfile, expandHome,
-  ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex,
+  ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex, detectGemini,
   syncProfile, syncAllProfiles, checkAllProfiles,
   launchProfile, getLastProfile, recordHistory, getProfile,
   looksLikeSubcommand, adapterFor,
@@ -154,6 +154,10 @@ program
         if (detectCodex()) {
           console.log('\nCodex detected (~/.codex). Add a Codex profile with:');
           console.log('  aimux profile add codework --cli codex');
+        }
+        if (detectGemini()) {
+          console.log('\nGemini detected (~/.gemini). Add a Gemini profile with:');
+          console.log('  aimux profile add gem --cli gemini');
         }
       };
 

--- a/src/core/adapters/gemini.test.ts
+++ b/src/core/adapters/gemini.test.ts
@@ -54,6 +54,10 @@ describe('geminiAdapter sharing + auth metadata', () => {
     expect(a.authArgs()).toEqual([]); // no login subcommand; interactive OAuth
   });
 
+  it('refuses id-based resume (gemini resumes by index, not session id)', () => {
+    expect(() => adapterFor('gemini').resumeArgs('some-uuid')).toThrow(/not supported/);
+  });
+
   it('runs headless via -p on stdout and needs no overlay/extra links', () => {
     const a = adapterFor('gemini');
     expect(a.headlessArgs('hi')).toEqual(['-p', 'hi']);

--- a/src/core/adapters/gemini.test.ts
+++ b/src/core/adapters/gemini.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { adapterFor } from './index.js';
+
+describe('geminiAdapter run-path', () => {
+  it('is selected for cli "gemini"', () => {
+    expect(adapterFor('gemini').id).toBe('gemini');
+  });
+
+  it('emits -m <model> when set and not a subcommand', () => {
+    const a = adapterFor('gemini');
+    expect(a.modelArgs({ model: 'gemini-2.5-pro', isSubcommand: false, userPassedModel: false, userPassedFallback: false }))
+      .toEqual(['-m', 'gemini-2.5-pro']);
+  });
+
+  it('omits the model flag for a subcommand or a user-passed model', () => {
+    const a = adapterFor('gemini');
+    expect(a.modelArgs({ model: 'm', isSubcommand: true, userPassedModel: false, userPassedFallback: false })).toEqual([]);
+    expect(a.modelArgs({ model: 'm', isSubcommand: false, userPassedModel: true, userPassedFallback: false })).toEqual([]);
+  });
+
+  it('isolates via GEMINI_CLI_HOME = parent of the .gemini profile dir', () => {
+    const a = adapterFor('gemini');
+    // gemini reads <GEMINI_CLI_HOME>/.gemini, and the profile dir IS that .gemini.
+    expect(a.configDirEnv('/home/u/.aimux/profiles/g/.gemini', false)).toEqual({
+      GEMINI_CLI_HOME: '/home/u/.aimux/profiles/g',
+    });
+  });
+
+  it('sets no config-dir env for a source profile', () => {
+    expect(adapterFor('gemini').configDirEnv('/home/u/.gemini', true)).toEqual({});
+  });
+
+  it('places the profile config in a .gemini subdir', () => {
+    expect(adapterFor('gemini').configPathFor!('~/.aimux/profiles/g')).toBe('~/.aimux/profiles/g/.gemini');
+  });
+});
+
+describe('geminiAdapter sharing + auth metadata', () => {
+  it('shares only the knowledge allowlist, never auth/settings', () => {
+    const a = adapterFor('gemini');
+    const empty = new Set<string>();
+    for (const shared of ['GEMINI.md', 'skills', 'commands', 'extensions', 'memories']) {
+      expect(a.isShared(shared, empty)).toBe(true);
+    }
+    for (const priv of ['oauth_creds.json', 'google_accounts.json', 'settings.json', 'history', 'projects.json', 'state.json']) {
+      expect(a.isShared(priv, empty)).toBe(false);
+    }
+  });
+
+  it('proves auth via oauth_creds.json and sources from ~/.gemini', () => {
+    const a = adapterFor('gemini');
+    expect(a.credentialsFile()).toBe('oauth_creds.json');
+    expect(a.defaultSource()).toBe('~/.gemini');
+    expect(a.authArgs()).toEqual([]); // no login subcommand; interactive OAuth
+  });
+
+  it('runs headless via -p on stdout and needs no overlay/extra links', () => {
+    const a = adapterFor('gemini');
+    expect(a.headlessArgs('hi')).toEqual(['-p', 'hi']);
+    expect(a.headlessCaptureToFile).toBe(false);
+    expect(a.globalArgs(undefined)).toEqual([]);
+    expect(a.extraLinks('/home/u/.gemini')).toEqual([]);
+  });
+});
+
+describe('configPathFor default (claude/codex unchanged)', () => {
+  it('claude and codex do not relocate the profile dir', () => {
+    // configPathFor is optional; absent for claude/codex → base dir used as-is.
+    expect(adapterFor('claude').configPathFor).toBeUndefined();
+    expect(adapterFor('codex').configPathFor).toBeUndefined();
+  });
+});

--- a/src/core/adapters/gemini.ts
+++ b/src/core/adapters/gemini.ts
@@ -1,0 +1,82 @@
+import { join, dirname } from 'node:path';
+import { looksLikeSubcommand } from '../subcommand.js';
+import type { CliAdapter } from './types.js';
+
+// Gemini keeps auth + per-machine state in ~/.gemini (oauth_creds.json,
+// google_accounts.json, history/, projects.json, state.json, settings.json, …).
+// Sharing is an ALLOWLIST, like codex — only portable knowledge crosses profiles:
+//   - GEMINI.md   : the project/user instructions (analogue of CLAUDE.md / AGENTS.md)
+//   - skills      : `gemini skills`
+//   - commands    : custom slash commands
+//   - extensions  : `gemini extensions`
+//   - memories    : saved memories
+// Auth, history, projects.json, settings.json (carries the selected auth method) stay
+// PRIVATE so profiles don't leak credentials or fight over per-profile state.
+const GEMINI_SHARED_ENTRIES = new Set(['GEMINI.md', 'skills', 'commands', 'extensions', 'memories']);
+
+export const geminiAdapter: CliAdapter = {
+  id: 'gemini',
+
+  modelArgs({ model, isSubcommand, userPassedModel }) {
+    // gemini takes the model via `-m`; it has no `--fallback-model`, so fallbackModel
+    // is intentionally ignored.
+    if (!model || isSubcommand || userPassedModel) return [];
+    return ['-m', model];
+  },
+
+  configDirEnv(profilePath, isSource): Record<string, string> {
+    // gemini has no direct config-dir override: it reads `homedir()/.gemini`, where
+    // homedir() is `GEMINI_CLI_HOME || os.homedir()`. configPathFor makes the profile
+    // dir BE that `.gemini`, so pointing GEMINI_CLI_HOME one level up lands gemini's
+    // config exactly on the profile dir (where the shared symlinks live).
+    return isSource ? {} : { GEMINI_CLI_HOME: dirname(profilePath) };
+  },
+
+  configPathFor(baseDir) {
+    return join(baseDir, '.gemini');
+  },
+
+  isSubcommand(firstArg) {
+    return looksLikeSubcommand(firstArg);
+  },
+
+  isShared(entry) {
+    return GEMINI_SHARED_ENTRIES.has(entry);
+  },
+
+  authArgs() {
+    // gemini has no login subcommand; first interactive run drives the OAuth flow
+    // (or set GEMINI_API_KEY). Launch interactively and let the user authenticate.
+    return [];
+  },
+
+  credentialsFile() {
+    return 'oauth_creds.json';
+  },
+
+  defaultSource() {
+    return '~/.gemini';
+  },
+
+  resumeArgs(sessionId) {
+    // gemini resumes by per-project index or "latest" (`-r <index|latest>`), NOT by a
+    // session id — so id-based resume is best-effort and not wired into aimux's session
+    // list yet. Kept for interface completeness.
+    return ['-r', sessionId];
+  },
+
+  headlessArgs(prompt) {
+    // gemini -p prints the answer to stdout, like claude.
+    return ['-p', prompt];
+  },
+
+  headlessCaptureToFile: false,
+
+  globalArgs() {
+    return [];
+  },
+
+  extraLinks() {
+    return [];
+  },
+};

--- a/src/core/adapters/gemini.ts
+++ b/src/core/adapters/gemini.ts
@@ -58,11 +58,11 @@ export const geminiAdapter: CliAdapter = {
     return '~/.gemini';
   },
 
-  resumeArgs(sessionId) {
+  resumeArgs() {
     // gemini resumes by per-project index or "latest" (`-r <index|latest>`), NOT by a
-    // session id — so id-based resume is best-effort and not wired into aimux's session
-    // list yet. Kept for interface completeness.
-    return ['-r', sessionId];
+    // session id. Feeding it a uuid would silently target the wrong session, so fail
+    // loud instead — gemini resume isn't wired into aimux's id-based session list yet.
+    throw new Error('gemini resume by session id is not supported (gemini resumes by per-project index)');
   },
 
   headlessArgs(prompt) {

--- a/src/core/adapters/index.ts
+++ b/src/core/adapters/index.ts
@@ -1,12 +1,14 @@
 import type { CliAdapter } from './types.js';
 import { claudeAdapter } from './claude.js';
 import { codexAdapter } from './codex.js';
+import { geminiAdapter } from './gemini.js';
 
 export type { CliAdapter } from './types.js';
 
 const REGISTRY: Record<string, CliAdapter> = {
   claude: claudeAdapter,
   codex: codexAdapter,
+  gemini: geminiAdapter,
 };
 
 /** Select the adapter for a profile's `cli`. Unknown/custom values fall back to the

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -16,6 +16,12 @@ export interface CliAdapter {
   /** Env that points the CLI at an isolated config dir. Empty for the source profile. */
   configDirEnv(profilePath: string, isSource: boolean): Record<string, string>;
 
+  /** Transform a profile's base dir (`~/.aimux/profiles/<name>`) into the dir that IS the
+   *  CLI's config home. Most CLIs use the base dir as-is (default); gemini needs the
+   *  profile dir to be a `.gemini` subdir so `GEMINI_CLI_HOME` can point one level up.
+   *  Optional — when absent the base dir is used unchanged. */
+  configPathFor?(baseDir: string): string;
+
   /** Whether the first passthrough arg is a CLI subcommand (suppresses model flags). */
   isSubcommand(firstArg: string | undefined): boolean;
 

--- a/src/core/addProfile.test.ts
+++ b/src/core/addProfile.test.ts
@@ -29,4 +29,17 @@ describe('addProfile cli + shared_sources', () => {
     const updated = addProfile(cfg, 'codework', { cli: 'codex' });
     expect(updated.shared_sources?.codex).toBe('/custom/codex');
   });
+
+  it('puts a gemini profile in a .gemini dir and registers ~/.gemini as its source', () => {
+    const updated = addProfile(base(), 'gem', { cli: 'gemini' });
+    expect(updated.profiles.gem.cli).toBe('gemini');
+    // The profile path IS gemini's config dir (.gemini), so GEMINI_CLI_HOME points one up.
+    expect(updated.profiles.gem.path).toBe('~/.aimux/profiles/gem/.gemini');
+    expect(updated.shared_sources?.gemini).toBe('~/.gemini');
+  });
+
+  it('keeps claude/codex profile paths unchanged (no .gemini suffix)', () => {
+    expect(addProfile(base(), 'work', {}).profiles.work.path).toBe('~/.aimux/profiles/work');
+    expect(addProfile(base(), 'cx', { cli: 'codex' }).profiles.cx.path).toBe('~/.aimux/profiles/cx');
+  });
 });

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -56,7 +56,11 @@ export function addProfile(
     throw new Error(`Profile '${name}' already exists`);
   }
   const cli = options.cli ?? 'claude';
-  const profilePath = `~/.aimux/profiles/${name}`;
+  const baseDir = `~/.aimux/profiles/${name}`;
+  // Most CLIs use the base dir as their config home; gemini needs it to be a `.gemini`
+  // subdir (see geminiAdapter.configPathFor / configDirEnv).
+  const adapter = adapterFor(cli);
+  const profilePath = adapter.configPathFor ? adapter.configPathFor(baseDir) : baseDir;
   const updated = { ...config };
   updated.profiles = {
     ...config.profiles,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,6 +40,7 @@ export type { SyncResult, HealthReport } from './symlinks.js';
 export {
   detectClaudeDirs,
   detectCodex,
+  detectGemini,
   initFromSource,
   initAutoDetect,
 } from './init.js';

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -90,6 +90,24 @@ export function detectCodex(): string | null {
   return contents.some((item) => CODEX_MARKERS.includes(item)) ? codexPath : null;
 }
 
+export function detectGemini(): string | null {
+  const geminiPath = join(homedir(), '.gemini');
+  if (!existsSync(geminiPath)) return null;
+  try {
+    if (!lstatSync(geminiPath).isDirectory()) return null;
+  } catch {
+    return null;
+  }
+  const GEMINI_MARKERS = ['oauth_creds.json', 'GEMINI.md', 'settings.json', 'installation_id'];
+  let contents: string[];
+  try {
+    contents = readdirSync(geminiPath);
+  } catch {
+    return null;
+  }
+  return contents.some((item) => GEMINI_MARKERS.includes(item)) ? geminiPath : null;
+}
+
 export function initFromSource(
   sourcePath: string,
   extraProfiles?: Array<{ name: string; existingPath?: string; model?: string }>,


### PR DESCRIPTION
Adds **Gemini** as a third AI CLI alongside claude and codex. A Gemini profile runs `gemini` under an isolated config dir and shares the same knowledge model as the other CLIs. **287 tests; verified end-to-end on the real gemini CLI (0.38.2).**

## Usage
```bash
aimux profile add gem --cli gemini   # ~/.gemini becomes the shared source
aimux run gem                         # launches `gemini -m <model>` isolated
aimux use gem                         # or activate it in the shell (nvm-use style)
```

## How it works
- **Sharing (allowlist):** `GEMINI.md`, `skills`, `commands`, `extensions`, `memories` are symlinked from `~/.gemini`; auth (`oauth_creds.json`/`google_accounts.json`), `settings.json`, and history stay **private** per profile. Verified end-to-end: shared entries symlinked, auth/settings not.
- **The config-dir wrinkle:** gemini has no `CLAUDE_CONFIG_DIR`/`CODEX_HOME` equivalent — it reads `<GEMINI_CLI_HOME || os.homedir()>/.gemini`. So the adapter makes the **profile dir itself** gemini's `.gemini` (new optional `CliAdapter.configPathFor`) and sets `GEMINI_CLI_HOME` to its parent. The existing sync/run code then lands the shared symlinks exactly where gemini looks — no core changes.
- **claude/codex untouched:** `configPathFor` is optional and absent for them, so their profile paths and behavior are byte-identical.
- `detectGemini()` + an `aimux init` hint when `~/.gemini` exists.

## Known limitation (documented)
Gemini resumes by per-project **index** (`-r latest`), not by session id, so cross-Gemini native resume isn't wired into aimux's session list/usage yet (those need a gemini-specific session scanner — a separate follow-up). `run` / `use` / `auth` / knowledge-sharing all work now.

## Tests
New `gemini.test.ts` (adapter run-path, sharing allowlist, auth metadata, configPathFor) + addProfile cases (gemini path → `.gemini`, claude/codex paths unchanged). Full suite 287 passing; tsc clean.