### PR TITLE
fix: share codex SQLite session-index DB so `run <codex> resume` lists all sessions (0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.21.1] - 2026-06-29
+
+### Fixed
+- **`aimux run <codex-profile> resume` now shows the same sessions as plain `codex
+  resume`.** codex 0.14x moved its resume-picker index out of `session_index.jsonl`
+  into a schema-versioned SQLite DB (`state_<N>.sqlite`, the `threads` table), which
+  aimux didn't share — so a codex profile's picker showed a stale/near-empty list
+  while plain `codex` in the same dir (reading the source DB) showed everything. The
+  session-index DB is now shared like `sessions/`: a profile symlinks it to the source
+  of truth (`~/.codex/state_<N>.sqlite`), so every codex profile sees the full thread
+  list. The `-wal`/`-shm` sidecars are intentionally not shared — SQLite recreates them
+  next to the symlink's resolved (source) path and checkpoints them on close, so
+  concurrent profiles are as safe as two plain `codex` against one home.
+  - Existing profiles are migrated automatically: a profile's stale real
+    `state_<N>.sqlite` is reclaimed (replaced by the source symlink) on the next sync /
+    `aimux rebuild`, since the source DB is authoritative codex-managed state (its
+    `threads` are backfilled from the already-shared `sessions/` rollouts), never user
+    data. A new optional `CliAdapter.reclaimsFromSource` gates this; claude/gemini keep
+    the safe skip-on-conflict default.
+
 ## [0.21.0] - 2026-06-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-threads/aimux",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -66,6 +66,31 @@ describe('codexAdapter auth/source metadata', () => {
   });
 });
 
+describe('codex session-index DB sharing', () => {
+  it('shares state_<N>.sqlite (the threads/resume index moved to SQLite in codex 0.14x)', () => {
+    const a = adapterFor('codex');
+    expect(a.isShared('state_5.sqlite', new Set())).toBe(true);
+    expect(a.isShared('state_12.sqlite', new Set())).toBe(true);
+    // not the transient sidecars (SQLite recreates them next to the source) or logs
+    expect(a.isShared('state_5.sqlite-wal', new Set())).toBe(false);
+    expect(a.isShared('logs_2.sqlite', new Set())).toBe(false);
+    expect(a.isShared('auth.json', new Set())).toBe(false);
+  });
+
+  it('reclaims a stale real state_<N>.sqlite from the source (it is authoritative)', () => {
+    const a = adapterFor('codex');
+    expect(a.reclaimsFromSource?.('state_5.sqlite')).toBe(true);
+    // never reclaim auth or other private real files
+    expect(a.reclaimsFromSource?.('auth.json')).toBe(false);
+    expect(a.reclaimsFromSource?.('logs_2.sqlite')).toBe(false);
+  });
+
+  it('claude/gemini do not reclaim conflicts (preserve the skip-on-conflict guard)', () => {
+    expect(adapterFor('claude').reclaimsFromSource).toBeUndefined();
+    expect(adapterFor('gemini').reclaimsFromSource).toBeUndefined();
+  });
+});
+
 describe('resumeArgs', () => {
   it('codex resumes via "resume <id>" (overlay added by globalArgs; no fork flag)', () => {
     // resumeArgs no longer hardcodes -p; the single injection point is globalArgs(),

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -15,6 +15,15 @@ import type { CliAdapter } from './types.js';
 // carries the source's model/features/[plugins]/[marketplaces] when layered via `-p aimux`.
 const CODEX_SHARED_ENTRIES = new Set(['skills', 'rules', 'memories', 'sessions', 'session_index.jsonl']);
 
+// codex 0.14x moved the session/resume index out of session_index.jsonl into a SQLite DB
+// (`state_<N>.sqlite`, schema-versioned; the picker reads its `threads` table). Share it
+// too, or `aimux run <codex> resume` shows an empty/stale list while plain `codex resume`
+// (reading the source DB) shows everything. The `-wal`/`-shm` sidecars are NOT shared:
+// SQLite recreates them next to the symlink's resolved (source) path on its own.
+function isSessionStateDb(entry: string): boolean {
+  return /^state_\d+\.sqlite$/.test(entry);
+}
+
 // The overlay profile name: codex layers `$CODEX_HOME/<name>.config.toml` on top of the
 // base config when invoked with `-p <name>`. Verified: codex reads it, never writes it.
 const OVERLAY_PROFILE = 'aimux';
@@ -50,7 +59,15 @@ export const codexAdapter: CliAdapter = {
   },
 
   isShared(entry) {
-    return CODEX_SHARED_ENTRIES.has(entry);
+    return CODEX_SHARED_ENTRIES.has(entry) || isSessionStateDb(entry);
+  },
+
+  reclaimsFromSource(entry) {
+    // The session-index DB is codex-managed state, not user data, and the source is
+    // authoritative (its `threads` are backfilled from the shared `sessions/` rollouts).
+    // So a profile's stale real copy should be replaced by the source symlink on sync —
+    // this migrates existing codex profiles to the shared resume index automatically.
+    return isSessionStateDb(entry);
   },
 
   authArgs() {

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -30,6 +30,12 @@ export interface CliAdapter {
    *  may share only an allowlist of knowledge dirs. `configPrivate` is `config.private`. */
   isShared(entry: string, configPrivate: Set<string>): boolean;
 
+  /** Whether a profile's REAL (non-symlink) file at a shared entry should be replaced by
+   *  the source symlink on sync, instead of being left as a conflict. Use only for
+   *  source-authoritative state (codex's session-index DB) — never for user data.
+   *  Optional; absent → conflicts are preserved (the safe default). */
+  reclaimsFromSource?(entry: string): boolean;
+
   /** Args to launch the CLI's interactive auth/login flow (claude: `auth login`;
    *  codex: `login`). */
   authArgs(): string[];

--- a/src/core/symlinks.test.ts
+++ b/src/core/symlinks.test.ts
@@ -51,6 +51,60 @@ afterEach(() => {
   rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
+describe('syncProfile reclaims codex session-index DB', () => {
+  it('replaces a stale REAL state_<N>.sqlite in the profile with the source symlink', () => {
+    const codexSrc = join(TEST_DIR, 'codex-src');
+    const profileDir = join(PROFILES_DIR, 'cx');
+    mkdirSync(codexSrc, { recursive: true });
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(join(codexSrc, 'state_5.sqlite'), 'SOURCE-INDEX-126');
+    writeFileSync(join(codexSrc, 'auth.json'), 'src-auth');
+    // The profile already has a stale, real (non-symlink) index from an earlier run.
+    writeFileSync(join(profileDir, 'state_5.sqlite'), 'STALE-INDEX-4');
+
+    const config = makeConfig({
+      shared_sources: { codex: codexSrc },
+      profiles: {
+        main: { cli: 'claude', path: SHARED_DIR, is_source: true },
+        cx: { cli: 'codex', path: profileDir },
+      },
+    });
+    const result = syncProfile(config, 'cx');
+
+    const dbPath = join(profileDir, 'state_5.sqlite');
+    expect(lstatSync(dbPath).isSymbolicLink()).toBe(true);
+    expect(readFileSync(dbPath, 'utf-8')).toBe('SOURCE-INDEX-126'); // now reads source
+    expect(result.repaired).toContain('state_5.sqlite');
+    expect(result.conflicts).not.toContain('state_5.sqlite');
+    // auth.json is private — never shared, never reclaimed.
+    expect(result.private).toContain('auth.json');
+  });
+
+  it('does NOT reclaim a directory at the entry path — falls through to conflicts (no EISDIR)', () => {
+    const codexSrc = join(TEST_DIR, 'codex-src-dir');
+    const profileDir = join(PROFILES_DIR, 'cxdir');
+    mkdirSync(codexSrc, { recursive: true });
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(join(codexSrc, 'state_5.sqlite'), 'SOURCE');
+    // Pathological: a real DIRECTORY where the DB belongs. unlinkSync would EISDIR
+    // and abort the whole sync, so the isFile() guard must skip it to conflicts.
+    mkdirSync(join(profileDir, 'state_5.sqlite'), { recursive: true });
+
+    const config = makeConfig({
+      shared_sources: { codex: codexSrc },
+      profiles: {
+        main: { cli: 'claude', path: SHARED_DIR, is_source: true },
+        cxdir: { cli: 'codex', path: profileDir },
+      },
+    });
+    // Must not throw, and must record a conflict rather than reclaiming.
+    const result = syncProfile(config, 'cxdir');
+    expect(result.conflicts).toContain('state_5.sqlite');
+    expect(result.repaired).not.toContain('state_5.sqlite');
+    expect(lstatSync(join(profileDir, 'state_5.sqlite')).isDirectory()).toBe(true);
+  });
+});
+
 describe('getSharedElements', () => {
   it('returns non-private entries', () => {
     seedShared(['settings.json', 'CLAUDE.md', '.credentials.json']);

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -322,6 +322,14 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
           symlinkSync(sourceTarget, targetInProfile);
           result.repaired.push(entry);
         }
+      } else if (adapter.reclaimsFromSource?.(entry) && stat.isFile()) {
+        // A real file where a source-authoritative entry (codex's session-index DB)
+        // belongs — replace it with the source symlink instead of leaving a conflict.
+        // Guarded to a regular file: a directory at this path would make unlinkSync
+        // throw EISDIR and abort the whole sync, so it falls through to `conflicts`.
+        unlinkSync(targetInProfile);
+        symlinkSync(sourceTarget, targetInProfile);
+        result.repaired.push(entry);
       } else {
         result.conflicts.push(entry);
       }


### PR DESCRIPTION
## The bug

`aimux run <codex-profile> resume` showed an empty / stale session list, while plain `codex resume` in the **same** directory showed everything.

## Root cause

codex 0.14x moved its resume-picker index out of the legacy `session_index.jsonl` and into a schema-versioned SQLite DB — `state_<N>.sqlite`, whose `threads` table is what the picker reads. aimux shares codex knowledge via an allowlist (`sessions/` + `session_index.jsonl` + skills/rules/memories) symlinked from the source of truth `~/.codex`. The new `state_<N>.sqlite` wasn't in that allowlist, so every profile kept a **private, stale** copy of the index.

Verified live: source `~/.codex/state_5.sqlite` had **126** threads; the profile's stale copy had **4**.

## The fix

Share `state_<N>.sqlite` like `sessions/`: each profile symlinks it to the source DB, so every codex profile sees the full thread list.

- The `-wal` / `-shm` sidecars are **not** shared — SQLite canonicalizes the symlink so they land next to the resolved (source) path and are checkpointed on close. Two profiles against one source DB is exactly as safe as two plain `codex` against one `~/.codex` (POSIX WAL locking). Verified empirically.
- **Auto-migration for existing profiles:** a profile's stale *real* `state_<N>.sqlite` is reclaimed (replaced by the source symlink) on the next sync / `aimux rebuild`, via a new optional `CliAdapter.reclaimsFromSource`. It's gated to source-authoritative codex-managed state (the `threads` are backfilled from the already-shared rollouts) — **never user data**, since the sync loop only iterates entries that exist in the source. The reclaim branch is further guarded to a regular file, so a directory at that path falls through to `conflicts` instead of aborting the sync with `EISDIR`. claude/gemini omit the method and keep the safe skip-on-conflict default.

## Verification

- Live: after `aimux rebuild cx`, `~/.aimux/profiles/cx/state_5.sqlite` is a symlink → `~/.codex/state_5.sqlite` and the profile now sees **126** threads (was 4). `aimux run cx resume` lists every session.
- Full suite: **292 → 293** tests pass (added reclaim integration test + a directory-edge-case guard test + codex adapter predicate tests). `tsc` build clean.
- Reviewed by harsh-code-reviewer: verdict *merge*; its one latent-footgun note (unguarded `unlinkSync` on a directory) is fixed in this PR.

Bumps **0.21.0 → 0.21.1**.