### PR TITLE
Shell UX, Robustness & Reliability Improvements

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1037,5 +1037,62 @@ program
     }
   });
 
+program
+  .command('logs [session]')
+  .description('View and grep chat transcripts of a session')
+  .option('--last', 'View logs of the most recent session')
+  .option('-g, --grep <query>', 'Filter transcript lines matching the query')
+  .action(async (session: string | undefined, options: { last?: boolean; grep?: string }) => {
+    try {
+      const config = requireConfig();
+      if (!session && !options.last) {
+        console.error('Error: Please specify a session ID or use --last');
+        process.exit(1);
+      }
+
+      const { unifyAllSessions } = await import('./core/unifiedSessions.js');
+      const { readTranscript } = await import('./core/handoff.js');
+      const { formatTranscript } = await import('./core/index.js');
+
+      const all = unifyAllSessions(config, { windowDays: Infinity });
+      let target: any;
+      if (options.last) {
+        target = all[0];
+      } else {
+        target = all.find(s => s.sessionId === session || s.short === session);
+      }
+
+      if (!target) {
+        console.error(`Error: Session '${session || 'last'}' not found`);
+        process.exit(1);
+      }
+
+      const raw = readTranscript(config, target);
+      if (!raw) {
+        console.error('Error: No transcript log found for this session');
+        process.exit(1);
+      }
+
+      const formatted = formatTranscript(raw);
+
+      if (options.grep) {
+        const query = options.grep.toLowerCase();
+        const matches = formatted.filter(f => f.toLowerCase().includes(query));
+        if (matches.length === 0) {
+          console.log('(No matching lines found)');
+        } else {
+          console.log(matches.join('\n\n'));
+        }
+      } else {
+        console.log(formatted.join('\n\n'));
+      }
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
 program.parse();
+
+
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,7 +10,7 @@ import {
   loadConfig, saveConfig, addProfile, removeProfile, expandHome,
   ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex, detectGemini,
   syncProfile, syncAllProfiles, checkAllProfiles,
-  launchProfile, getLastProfile, recordHistory, getProfile,
+  launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
   loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson, confirm,
@@ -207,27 +207,32 @@ program
 
       if (!profileName) {
         const cwd = process.cwd();
-        const last = getLastProfile(cwd);
-        const names = Object.keys(config.profiles);
-
-        if (names.length === 1) {
-          profileName = names[0];
+        const boundProfile = resolveProfileForDir(config, cwd);
+        if (boundProfile) {
+          profileName = boundProfile;
         } else {
-          const { render } = await import('ink');
-          const { ProfilePicker } = await import('./components/ProfilePicker.js');
-          let selectedProfile: string | undefined;
-          const { waitUntilExit } = render(
-            <ProfilePicker
-              config={config}
-              lastProfile={last}
-              onSelect={(selected: string) => {
-                selectedProfile = selected;
-              }}
-            />
-          );
-          await waitUntilExit();
-          if (!selectedProfile) return;
-          profileName = selectedProfile;
+          const last = getLastProfile(cwd);
+          const names = Object.keys(config.profiles);
+
+          if (names.length === 1) {
+            profileName = names[0];
+          } else {
+            const { render } = await import('ink');
+            const { ProfilePicker } = await import('./components/ProfilePicker.js');
+            let selectedProfile: string | undefined;
+            const { waitUntilExit } = render(
+              <ProfilePicker
+                config={config}
+                lastProfile={last}
+                onSelect={(selected: string) => {
+                  selectedProfile = selected;
+                }}
+              />
+            );
+            await waitUntilExit();
+            if (!selectedProfile) return;
+            profileName = selectedProfile;
+          }
         }
       }
 
@@ -269,24 +274,30 @@ program
 
       let profileName = profile;
       if (!profileName) {
-        const names = Object.keys(config.profiles);
-        if (names.length === 1) {
-          profileName = names[0];
+        const cwd = process.cwd();
+        const boundProfile = resolveProfileForDir(config, cwd);
+        if (boundProfile) {
+          profileName = boundProfile;
         } else {
-          const { render } = await import('ink');
-          const { ProfilePicker } = await import('./components/ProfilePicker.js');
-          const last = getLastProfile(process.cwd());
-          let selected: string | undefined;
-          // Under the shell wrapper, --export's stdout is captured by command
-          // substitution, so draw the picker on stderr (still a TTY) to keep
-          // stdout eval-clean. Direct invocation draws on stdout as usual.
-          const { waitUntilExit } = render(
-            <ProfilePicker config={config} lastProfile={last} onSelect={(s: string) => { selected = s; }} />,
-            options.export ? { stdout: process.stderr } : undefined,
-          );
-          await waitUntilExit();
-          if (!selected) return;
-          profileName = selected;
+          const names = Object.keys(config.profiles);
+          if (names.length === 1) {
+            profileName = names[0];
+          } else {
+            const { render } = await import('ink');
+            const { ProfilePicker } = await import('./components/ProfilePicker.js');
+            const last = getLastProfile(cwd);
+            let selected: string | undefined;
+            // Under the shell wrapper, --export's stdout is captured by command
+            // substitution, so draw the picker on stderr (still a TTY) to keep
+            // stdout eval-clean. Direct invocation draws on stdout as usual.
+            const { waitUntilExit } = render(
+              <ProfilePicker config={config} lastProfile={last} onSelect={(s: string) => { selected = s; }} />,
+              options.export ? { stdout: process.stderr } : undefined,
+            );
+            await waitUntilExit();
+            if (!selected) return;
+            profileName = selected;
+          }
         }
       }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,7 +10,7 @@ import {
   loadConfig, saveConfig, addProfile, removeProfile, expandHome,
   ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex, detectGemini,
   syncProfile, syncAllProfiles, checkAllProfiles,
-  launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile,
+  launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile, loadActiveProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
   loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson, confirm,
@@ -937,7 +937,7 @@ program
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  commands="init run status usage profile rebuild doctor auth completions"
+  commands="init run status usage profile rebuild doctor auth prompt-indicator prompt completions"
 
   case "\${prev}" in
     run|auth)
@@ -957,7 +957,7 @@ complete -F _aimux aimux
       console.log(`#compdef aimux
 _aimux() {
   local -a commands profiles
-  commands=(init run status usage profile rebuild doctor auth completions)
+  commands=(init run status usage profile rebuild doctor auth prompt-indicator prompt completions)
   profiles=(${profiles})
 
   _arguments '1:command:($commands)' '*::arg:->args'
@@ -974,7 +974,7 @@ _aimux() {
 _aimux
 # Add to ~/.zshrc: eval "$(aimux completions zsh)"`);
     } else if (shell === 'fish') {
-      console.log(`complete -c aimux -n '__fish_use_subcommand' -a 'init run status usage profile rebuild doctor auth completions'
+      console.log(`complete -c aimux -n '__fish_use_subcommand' -a 'init run status usage profile rebuild doctor auth prompt-indicator prompt completions'
 complete -c aimux -n '__fish_seen_subcommand_from run' -a '${profiles}'
 complete -c aimux -n '__fish_seen_subcommand_from profile' -a 'add list update remove clone'
 complete -c aimux -n '__fish_seen_subcommand_from auth' -a 'login status'
@@ -1018,4 +1018,24 @@ program
     console.log(`\nReload with: source ${rcFile}`);
   });
 
+program
+  .command('prompt-indicator')
+  .alias('prompt')
+  .description('Print the active profile name (for zsh/bash/Starship prompt)')
+  .option('-f, --format <pattern>', 'Format pattern (e.g. "[aimux: %s]"). If omitted, outputs raw profile name.')
+  .action((options: { format?: string }) => {
+    try {
+      const active = process.env.AIMUX_PROFILE || loadActiveProfile();
+      if (!active) return;
+      if (options.format) {
+        console.log(options.format.replace('%s', active));
+      } else {
+        console.log(active);
+      }
+    } catch {
+      // fail silently so shell prompts do not break/spew errors
+    }
+  });
+
 program.parse();
+

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -511,7 +511,7 @@ program
 
       type PendingAction =
         | { type: 'exit' }
-        | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean; cli: string };
+        | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean; cli: string; fork?: boolean };
 
       const { existsSync: existsSyncFn } = await import('node:fs');
 
@@ -554,7 +554,8 @@ program
             const cwd = action.cwd && existsSyncFn(action.cwd) ? action.cwd : undefined;
             const code = await resumeSession(config, action.profile, action.sessionId, {
               cwd,
-              forkSession: action.live,
+              forkSession: action.fork !== false && action.live,
+              attachLive: action.fork === false && action.live,
             });
             recordSessionUsage(action.sessionId, action.profile);
             if (code !== 0) console.error(`Resume exited with code ${code}`);

--- a/src/components/AgentsView.tsx
+++ b/src/components/AgentsView.tsx
@@ -14,14 +14,14 @@ import { summarizeUsage, totalTokens, type ProfileUsageSummary } from '../core/u
 
 export type AgentsAction =
   | { type: 'exit' }
-  | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean; cli: string };
+  | { type: 'attach'; profile: string; sessionId: string; cwd: string; live: boolean; cli: string; fork?: boolean };
 
 interface Props {
   config: AimuxConfig;
   onAction: (action: AgentsAction) => void;
 }
 
-type ViewMode = 'list' | 'dispatch' | 'filter' | 'help' | 'pickActiveProfile' | 'pickAttachProfile';
+type ViewMode = 'list' | 'dispatch' | 'filter' | 'help' | 'pickActiveProfile' | 'pickAttachProfile' | 'pickAttachMode';
 type GroupMode = 'recency' | 'cwd' | 'state' | 'flat';
 
 interface SessionRow {
@@ -274,6 +274,8 @@ export function AgentsView({ config, onAction }: Props) {
   const [dispatchPrompt, setDispatchPrompt] = useState('');
   const [dispatchProfileDraft, setDispatchProfileDraft] = useState<string>(initialActive);
   const [profilePickerIdx, setProfilePickerIdx] = useState(0);
+  const [attachProfileDraft, setAttachProfileDraft] = useState<string>('');
+  const [attachModeIdx, setAttachModeIdx] = useState<number>(0);
   const [showAll, setShowAll] = useState(false);
   const [viewportTop, setViewportTop] = useState(0);
   const [toast, setToast] = useState('');
@@ -548,7 +550,7 @@ export function AgentsView({ config, onAction }: Props) {
   const currentSession = currentRow?.kind === 'session' ? currentRow.session : undefined;
   selectedIdRef.current = currentSession?.sessionId;
 
-  const doAttach = (profile: string) => {
+  const doAttach = (profile: string, fork?: boolean) => {
     if (!currentSession) return;
     onAction({
       type: 'attach',
@@ -561,6 +563,7 @@ export function AgentsView({ config, onAction }: Props) {
         currentSession.state !== 'done' &&
         currentSession.state !== 'failed' &&
         currentSession.state !== 'stopped',
+      fork,
     });
     exit();
   };
@@ -568,6 +571,26 @@ export function AgentsView({ config, onAction }: Props) {
   useInput((input, key) => {
     if (mode === 'help') {
       if (key.escape || input === '?' || input === 'q') setMode('list');
+      return;
+    }
+
+    if (mode === 'pickAttachMode') {
+      if (key.escape) {
+        setMode('list');
+        return;
+      }
+      if (key.upArrow) {
+        setAttachModeIdx((i) => (i > 0 ? i - 1 : 1));
+        return;
+      }
+      if (key.downArrow) {
+        setAttachModeIdx((i) => (i < 1 ? i + 1 : 0));
+        return;
+      }
+      if (key.return) {
+        setMode('list');
+        doAttach(attachProfileDraft, attachModeIdx === 1);
+      }
       return;
     }
 
@@ -590,8 +613,18 @@ export function AgentsView({ config, onAction }: Props) {
           setActiveProfile(chosen);
           setMode('list');
         } else {
-          setMode('list');
-          doAttach(chosen);
+          const isLive = currentSession?.isBackground &&
+            currentSession.state !== 'done' &&
+            currentSession.state !== 'failed' &&
+            currentSession.state !== 'stopped';
+          if (isLive) {
+            setAttachProfileDraft(chosen);
+            setAttachModeIdx(0);
+            setMode('pickAttachMode');
+          } else {
+            setMode('list');
+            doAttach(chosen);
+          }
         }
       }
       return;
@@ -657,7 +690,19 @@ export function AgentsView({ config, onAction }: Props) {
     else if (key.downArrow) moveCursor(1);
     else if (key.tab) jumpToNextGroup();
     else if (key.return || key.rightArrow) {
-      if (currentSession) doAttach(activeProfile);
+      if (currentSession) {
+        const isLive = currentSession.isBackground &&
+          currentSession.state !== 'done' &&
+          currentSession.state !== 'failed' &&
+          currentSession.state !== 'stopped';
+        if (isLive) {
+          setAttachProfileDraft(activeProfile);
+          setAttachModeIdx(0);
+          setMode('pickAttachMode');
+        } else {
+          doAttach(activeProfile);
+        }
+      }
     } else if (input === ' ') {
       if (currentSession) setPeekOpen((v) => !v);
     } else if (input === 'n') {
@@ -709,6 +754,14 @@ export function AgentsView({ config, onAction }: Props) {
         cursor={profilePickerIdx}
         activeProfile={activeProfile}
         sessionLastProfile={currentSession?.lastProfile}
+      />
+    );
+  }
+  if (mode === 'pickAttachMode') {
+    return (
+      <AttachModePickerModal
+        sessionName={currentSession?.name ?? ''}
+        cursor={attachModeIdx}
       />
     );
   }
@@ -892,6 +945,39 @@ function HelpOverlay({ activeProfile }: { activeProfile: string }) {
       ))}
       <Text> </Text>
       <Text dimColor>Press ? or Esc to close</Text>
+    </Box>
+  );
+}
+
+function AttachModePickerModal({
+  sessionName,
+  cursor,
+}: {
+  sessionName: string;
+  cursor: number;
+}) {
+  const options = [
+    { label: 'Attach to live running session (join)', desc: 'Connects directly to the active process without creating a new copy' },
+    { label: 'Fork copy (starts a new thread)', desc: 'Spawns a new process, copying the conversation history to avoid conflicts' },
+  ];
+
+  return (
+    <Box flexDirection="column" paddingX={2} paddingY={1}>
+      <Text bold color="cyan">Choose attach mode for "{sessionName}"</Text>
+      <Text> </Text>
+      {options.map((opt, i) => {
+        const sel = i === cursor;
+        return (
+          <Box key={i} flexDirection="column" marginY={0.5}>
+            <Text color={sel ? 'cyan' : undefined} bold={sel}>
+              {sel ? '❯' : ' '} {opt.label}
+            </Text>
+            <Text dimColor>   {opt.desc}</Text>
+          </Box>
+        );
+      })}
+      <Text> </Text>
+      <Text dimColor>↑↓ navigate · Enter select · Esc cancel</Text>
     </Box>
   );
 }

--- a/src/core/adapters/claude.ts
+++ b/src/core/adapters/claude.ts
@@ -45,6 +45,11 @@ export const claudeAdapter: CliAdapter = {
     return args;
   },
 
+  attachArgs(sessionId) {
+    return ['attach', sessionId];
+  },
+
+
   headlessArgs(prompt) {
     return ['-p', prompt];
   },

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -114,6 +114,12 @@ describe('resumeArgs', () => {
     expect(adapterFor('claude').resumeArgs('id-1')).toEqual(['--resume', 'id-1']);
     expect(adapterFor('claude').resumeArgs('id-1', { fork: true })).toEqual(['--resume', 'id-1', '--fork-session']);
   });
+
+  it('claude attaches to live running session without forking', () => {
+    const c = adapterFor('claude');
+    expect(c.attachArgs).toBeDefined();
+    expect(c.attachArgs!('id-1')).toEqual(['attach', 'id-1']);
+  });
 });
 
 describe('headlessArgs (summarizer capture)', () => {

--- a/src/core/adapters/codex.test.ts
+++ b/src/core/adapters/codex.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { spawnSync } from 'node:child_process';
 import { adapterFor } from './index.js';
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawnSync: vi.fn().mockReturnValue({ status: 0 }),
+  };
+});
+
 
 describe('codexAdapter run-path', () => {
   it('is selected for cli "codex"', () => {
@@ -156,3 +166,31 @@ describe('codex overlay (globalArgs + extraLinks)', () => {
     expect(adapterFor('claude').extraLinks('/home/u/.claude')).toEqual([]);
   });
 });
+
+describe('codexAdapter onPostSync', () => {
+  it('runs sqlite3 WAL configuration on a session state DB', () => {
+    const a = adapterFor('codex');
+    const spawnSpy = vi.mocked(spawnSync);
+    spawnSpy.mockClear();
+
+    a.onPostSync?.('/path/to/source', 'state_5.sqlite');
+
+    expect(spawnSpy).toHaveBeenCalledWith(
+      'sqlite3',
+      ['/path/to/source/state_5.sqlite', 'PRAGMA journal_mode=WAL;'],
+      { stdio: 'ignore' }
+    );
+  });
+
+  it('does not run sqlite3 on non-state DB entries', () => {
+    const a = adapterFor('codex');
+    const spawnSpy = vi.mocked(spawnSync);
+    spawnSpy.mockClear();
+
+    a.onPostSync?.('/path/to/source', 'rules');
+    a.onPostSync?.('/path/to/source', 'logs_2.sqlite');
+
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/core/adapters/codex.ts
+++ b/src/core/adapters/codex.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { looksLikeSubcommand } from '../subcommand.js';
 import type { CliAdapter } from './types.js';
@@ -111,4 +112,16 @@ export const codexAdapter: CliAdapter = {
       { link: 'plugins', target: join(sourceDir, 'plugins') },
     ];
   },
+
+  onPostSync(sourcePath, entry) {
+    if (isSessionStateDb(entry)) {
+      try {
+        const dbPath = join(sourcePath, entry);
+        spawnSync('sqlite3', [dbPath, 'PRAGMA journal_mode=WAL;'], { stdio: 'ignore' });
+      } catch {
+        // best effort
+      }
+    }
+  },
 };
+

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -48,9 +48,12 @@ export interface CliAdapter {
    *  for a freshly added non-claude profile (claude: `~/.claude`; codex: `~/.codex`). */
   defaultSource(): string;
 
-  /** Args to resume an existing session by id (claude: `--resume <id>` [+ `--fork-session`];
-   *  codex: `resume <id>`). */
   resumeArgs(sessionId: string, opts?: { fork?: boolean }): string[];
+
+  /** Args to attach to a currently running live session without forking (claude: `attach <id>`).
+   *  Optional. */
+  attachArgs?(sessionId: string): string[];
+
 
   /** Args for a non-interactive one-shot with a prompt, captured via runProfileHeadless.
    *  claude prints the answer to stdout (`-p <prompt>`); codex's stdout is noisy, so it

--- a/src/core/adapters/types.ts
+++ b/src/core/adapters/types.ts
@@ -73,4 +73,10 @@ export interface CliAdapter {
    *  this for its config overlay (`aimux.config.toml` → source `config.toml`) and plugin
    *  content. `sourceDir` is the CLI's source-of-truth dir. */
   extraLinks(sourceDir: string): Array<{ link: string; target: string }>;
+
+  /** Optional callback to configure or process a shared file after a successful sync/link.
+   *  `sourcePath` is the CLI's source-of-truth directory, and `entry` is the name of the
+   *  shared file/directory inside it. */
+  onPostSync?(sourcePath: string, entry: string): void;
 }
+

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -14,6 +14,8 @@ import {
   loadConfig,
   recordHistory,
   getLastProfile,
+  matchGlob,
+  resolveProfileForDir,
 } from './config.js';
 
 const TEST_DIR = join(tmpdir(), `aimux-test-${Date.now()}`);
@@ -150,3 +152,66 @@ describe('history', () => {
     expect(getLastProfile('/home/user/project-a')).toBe('own');
   });
 });
+
+describe('bindings config validation', () => {
+  it('validates bindings array structure', () => {
+    const config = createDefaultConfig('~/.claude');
+    expect(validateConfig(config)).toHaveLength(0);
+
+    // invalid type for bindings
+    const badConfig1 = { ...config, bindings: 'not-an-array' };
+    expect(validateConfig(badConfig1)).toContain('bindings must be an array of objects');
+
+    // non-object elements
+    const badConfig2 = { ...config, bindings: ['string'] };
+    expect(validateConfig(badConfig2)).toContain('bindings[0] must be an object');
+
+    // missing fields
+    const badConfig3 = { ...config, bindings: [{}] };
+    expect(validateConfig(badConfig3)).toContain('bindings[0]: pattern must be a non-empty string');
+    expect(validateConfig(badConfig3)).toContain('bindings[0]: profile must be a non-empty string');
+
+    // non-existent profile
+    const badConfig4 = { ...config, bindings: [{ pattern: '~/work/**', profile: 'non-existent' }] };
+    expect(validateConfig(badConfig4)).toContain("bindings[0]: profile 'non-existent' does not exist in profiles");
+
+    // valid binding
+    const goodConfig = { ...config, bindings: [{ pattern: '~/work/**', profile: 'main' }] };
+    expect(validateConfig(goodConfig)).toHaveLength(0);
+  });
+});
+
+describe('matchGlob', () => {
+  it('matches exact paths', () => {
+    expect(matchGlob('/home/user/work', '/home/user/work')).toBe(true);
+    expect(matchGlob('/home/user/work', '/home/user/other')).toBe(false);
+  });
+
+  it('matches segments using *', () => {
+    expect(matchGlob('/home/user/work/project', '/home/user/*/project')).toBe(true);
+    expect(matchGlob('/home/user/work/project', '/home/user/work/*')).toBe(true);
+    expect(matchGlob('/home/user/work/project', '/home/user/*')).toBe(false);
+  });
+
+  it('matches recursively using **', () => {
+    expect(matchGlob('/home/user/work/project/src/index.ts', '/home/user/work/**')).toBe(true);
+    expect(matchGlob('/home/user/work', '/home/user/work/**')).toBe(true);
+    expect(matchGlob('/home/user/other', '/home/user/work/**')).toBe(false);
+  });
+});
+
+describe('resolveProfileForDir', () => {
+  it('resolves bound profile when pattern matches', () => {
+    let config = createDefaultConfig('~/.claude');
+    config = addProfile(config, 'work', { model: 'opus-4-6' });
+    config.bindings = [
+      { pattern: '~/work/project1/**', profile: 'work' },
+      { pattern: '~/personal/**', profile: 'main' }
+    ];
+
+    expect(resolveProfileForDir(config, '~/work/project1/src')).toBe('work');
+    expect(resolveProfileForDir(config, '~/personal/dev')).toBe('main');
+    expect(resolveProfileForDir(config, '~/other')).toBeNull();
+  });
+});
+

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,9 +1,11 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 import { parse, stringify } from 'yaml';
 import type { AimuxConfig, ProfileConfig, HistoryEntry } from '../types/index.js';
 import { DEFAULT_CONFIG, DEFAULT_PRIVATE_ELEMENTS } from '../types/index.js';
 import { getConfigPath, getHistoryPath, getAimuxDir, getProfilesDir, expandHome } from './paths.js';
 import { adapterFor } from './adapters/index.js';
+
 
 export function loadConfig(): AimuxConfig | null {
   const configPath = getConfigPath();
@@ -184,8 +186,32 @@ export function validateConfig(config: unknown): string[] {
     errors.push('private must be an array of strings');
   }
 
+  if (c.bindings !== undefined) {
+    if (!Array.isArray(c.bindings)) {
+      errors.push('bindings must be an array of objects');
+    } else {
+      const profiles = (c.profiles || {}) as Record<string, unknown>;
+      for (let i = 0; i < c.bindings.length; i++) {
+        const b = c.bindings[i];
+        if (!b || typeof b !== 'object' || Array.isArray(b)) {
+          errors.push(`bindings[${i}] must be an object`);
+          continue;
+        }
+        if (typeof b.pattern !== 'string' || !b.pattern) {
+          errors.push(`bindings[${i}]: pattern must be a non-empty string`);
+        }
+        if (typeof b.profile !== 'string' || !b.profile) {
+          errors.push(`bindings[${i}]: profile must be a non-empty string`);
+        } else if (!profiles[b.profile]) {
+          errors.push(`bindings[${i}]: profile '${b.profile}' does not exist in profiles`);
+        }
+      }
+    }
+  }
+
   return errors;
 }
+
 
 // --- History ---
 
@@ -222,6 +248,75 @@ export function getLastProfile(dir: string): string | null {
   const entry = entries.find(e => e.dir === dir);
   return entry?.profile ?? null;
 }
+
+export function matchGlob(dir: string, pattern: string): boolean {
+  const cleanDir = resolve(expandHome(dir));
+  const cleanPattern = resolve(expandHome(pattern));
+
+  if (cleanDir === cleanPattern) return true;
+
+  const dirParts = cleanDir.split(sep);
+  const patternParts = cleanPattern.split(sep);
+
+  let d = 0;
+  let p = 0;
+  while (d < dirParts.length && p < patternParts.length) {
+    const part = patternParts[p];
+    if (part === '**') {
+      if (p === patternParts.length - 1) {
+        return true;
+      }
+      const nextPatternPart = patternParts[p + 1];
+      let found = false;
+      while (d < dirParts.length) {
+        if (matchSegment(dirParts[d], nextPatternPart)) {
+          found = true;
+          break;
+        }
+        d++;
+      }
+      if (!found) return false;
+      p += 2;
+      d++;
+      continue;
+    }
+
+    if (!matchSegment(dirParts[d], part)) {
+      return false;
+    }
+    d++;
+    p++;
+  }
+
+  if (d === dirParts.length && p === patternParts.length - 1 && patternParts[p] === '**') {
+    return true;
+  }
+
+  return d === dirParts.length && p === patternParts.length;
+}
+
+function matchSegment(segment: string, pattern: string): boolean {
+  if (pattern === '*') return true;
+  const regexStr = '^' + pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.') + '$';
+  const regex = new RegExp(regexStr);
+  return regex.test(segment);
+}
+
+export function resolveProfileForDir(config: AimuxConfig, dir: string): string | null {
+  if (config.bindings && config.bindings.length > 0) {
+    for (const binding of config.bindings) {
+      if (matchGlob(dir, binding.pattern) && config.profiles[binding.profile]) {
+        return binding.profile;
+      }
+    }
+  }
+  return null;
+}
+
+
 
 // --- Filesystem ---
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,10 +12,12 @@ export {
   saveHistory,
   recordHistory,
   getLastProfile,
+  resolveProfileForDir,
   configExists,
   ensureAimuxDir,
   ensureProfileDir,
 } from './config.js';
+
 
 export {
   expandHome,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -92,3 +92,6 @@ export { handoffSession, buildHandoffPrompt, buildSummarizePrompt, readTranscrip
 export type { HandoffDeps, HandoffResult } from './handoff.js';
 
 export { loadActiveProfile, saveActiveProfile, getActiveProfilePath } from './activeProfile.js';
+
+export { formatTranscript } from './logs.js';
+

--- a/src/core/liveSession.test.ts
+++ b/src/core/liveSession.test.ts
@@ -2,6 +2,30 @@ import { describe, it, expect, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
 import { buildSessionArgs, openSession, type SessionEvent } from './liveSession.js';
 import type { AimuxConfig } from '../types/index.js';
+import { fetchRateLimits } from './limits.js';
+
+vi.mock('./limits.js', () => ({
+  fetchRateLimits: vi.fn(),
+  classifyProfile: vi.fn(),
+  parseRateLimitHeaders: vi.fn(),
+}));
+
+vi.mock('./activeProfile.js', () => ({
+  saveActiveProfile: vi.fn(),
+  loadActiveProfile: vi.fn(() => null),
+  getActiveProfilePath: vi.fn(() => '/dummy/path'),
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs') as any;
+  return {
+    ...actual,
+    existsSync: (path: string) => {
+      if (path.includes('.credentials.json')) return true;
+      return actual.existsSync(path);
+    },
+  };
+});
 
 function makeConfig(): AimuxConfig {
   return {
@@ -178,5 +202,37 @@ describe('openSession', () => {
     const p = s.send('a'); procs[0].line({ type: 'result', result: '1' }); await p;
     expect(calls[0].args).toContain('--resume');
     expect(calls[0].args).not.toContain('--session-id');
+  });
+
+  it('automatically switches profile on rate limit (failover)', async () => {
+    const { calls, procs, spawnFn } = spy();
+
+    vi.mocked(fetchRateLimits).mockImplementation(async (profile: any) => {
+      if (profile.path.includes('work') || profile.path.includes('.claude')) {
+        return { fiveHourPct: 100, weeklyPct: 0, status: 'rate_limited' };
+      }
+      return { fiveHourPct: 10, weeklyPct: 0, status: 'allowed' };
+    });
+
+    const s = openSession(makeConfig(), 'work', { sessionId: 'sid', spawnFn });
+    const p = s.send('prompt text');
+
+    // First process spawned on work
+    expect(calls[0].env.CLAUDE_CONFIG_DIR).toBe('/home/user/.aimux/profiles/work');
+
+    // Simulate 429 rate limit error response
+    procs[0].line({ type: 'error', error: { message: 'Rate limit 429 exceeded' } });
+
+    // Wait a tick for the async failover logic to run and spawn the relocated process
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Wait for the relocated retry to receive result from backup
+    procs[1].line({ type: 'result', result: 'success from backup' });
+    const r = await p;
+
+    expect(r.text).toBe('success from backup');
+    expect(calls[1].args).toContain('--resume');
+    expect(calls[1].env.CLAUDE_CONFIG_DIR).toBe('/home/user/.aimux/profiles/backup');
+    expect(procs[0].killed).toBe(true);
   });
 });

--- a/src/core/liveSession.ts
+++ b/src/core/liveSession.ts
@@ -13,8 +13,14 @@
 // event carrying the text + total_cost_usd + permission_denials.
 
 import { spawn, type ChildProcess } from 'child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import { buildRunParams } from './run.js';
 import type { AimuxConfig } from '../types/index.js';
+import { adapterFor } from './adapters/index.js';
+import { fetchRateLimits } from './limits.js';
+import { saveActiveProfile } from './activeProfile.js';
+import { expandHome } from './paths.js';
 
 // The headless multi-turn protocol flags. Owned here, never exposed to callers.
 const STREAM_FLAGS = ['-p', '--verbose', '--input-format', 'stream-json', '--output-format', 'stream-json'];
@@ -70,6 +76,7 @@ export interface TurnResult {
   text: string;
   costUsd: number;
   denials: string[];
+  raw?: any;
 }
 
 export interface LiveSession {
@@ -174,10 +181,10 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
   // host restart) — so the very first send must --resume, not re-create.
   let everSpawned = !!opts.resume;
 
-  function settle(text: string, cost = 0, denials: string[] = []): void {
+  function settle(text: string, cost = 0, denials: string[] = [], raw?: any): void {
     const p = pending;
     pending = null;
-    p?.({ text, costUsd: cost, denials });
+    p?.({ text, costUsd: cost, denials, raw });
   }
 
   function onData(d: Buffer | string): void {
@@ -187,7 +194,7 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
       const line = buf.slice(0, i);
       buf = buf.slice(i + 1);
       if (!line.trim()) continue;
-      let ev: { type?: string; result?: string; total_cost_usd?: number; permission_denials?: unknown[]; message?: { content?: unknown } };
+      let ev: any;
       try { ev = JSON.parse(line); } catch { continue; }
       if (ev.type === 'assistant') {
         resetWatchdog?.(); // the agent is working — keep the watchdog from firing
@@ -203,7 +210,11 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
         }
         const text = ev.result ?? '';
         curEvent?.({ kind: 'result', text, raw: ev });
-        settle(text, ev.total_cost_usd ?? 0, turnDenials);
+        settle(text, ev.total_cost_usd ?? 0, turnDenials, ev);
+      } else if (ev.type === 'error') {
+        const errorText = ev.error?.message ?? JSON.stringify(ev.error ?? 'Unknown error');
+        curEvent?.({ kind: 'other', raw: ev });
+        settle(errorText, 0, [], ev);
       } else {
         curEvent?.({ kind: 'other', raw: ev });
       }
@@ -226,7 +237,7 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
     return child;
   }
 
-  return {
+  const session: LiveSession = {
     send(text, onEvent) {
       const child = ensure();
       curEvent = onEvent;
@@ -244,7 +255,27 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
         // long but actively-working turn (a big implementation) is not killed —
         // only a genuinely silent/stuck one is.
         resetWatchdog = () => { clearTimeout(timer); timer = arm(); };
-        pending = (r: TurnResult) => { clearTimeout(timer); resetWatchdog = null; resolve(r); };
+        pending = async (r: TurnResult) => {
+          clearTimeout(timer);
+          resetWatchdog = null;
+
+          if (isRateLimitError(r.text, r.raw)) {
+            const failover = await findFailoverProfile(config, profile);
+            if (failover) {
+              console.warn(`\x1b[33m⚠ Rate limit hit on profile '${profile}'. Auto-switching to '${failover}'…\x1b[0m`);
+              session.relocate(failover);
+              try {
+                saveActiveProfile(failover);
+              } catch {
+                // best-effort
+              }
+              const retryResult = await session.send(text, onEvent);
+              resolve(retryResult);
+              return;
+            }
+          }
+          resolve(r);
+        };
         child.stdin?.write(userMessage(text));
       });
     },
@@ -265,4 +296,58 @@ export function openSession(config: AimuxConfig, profileName: string, opts: Open
       if (proc) { try { proc.stdin?.end(); proc.kill(); } catch { /* best-effort */ } proc = null; }
     },
   };
+
+  return session;
+}
+
+function isRateLimitError(text: string, raw: any): boolean {
+  if (raw && typeof raw === 'object') {
+    if (raw.type === 'error') {
+      const msg = (raw.error?.message || JSON.stringify(raw.error || '')).toLowerCase();
+      const type = (raw.error?.type || '').toLowerCase();
+      if (msg.includes('rate limit') || msg.includes('429') || msg.includes('quota') || type.includes('rate_limit')) {
+        return true;
+      }
+    }
+  }
+  const lowerText = text.toLowerCase();
+  return (
+    lowerText.includes('rate limit') ||
+    lowerText.includes('rate_limit') ||
+    lowerText.includes('quota exceeded') ||
+    lowerText.includes('429') ||
+    lowerText.includes('overloaded')
+  );
+}
+
+async function findFailoverProfile(
+  config: AimuxConfig,
+  currentProfile: string,
+): Promise<string | null> {
+  const profileNames = Object.keys(config.profiles).filter((name) => name !== currentProfile);
+  for (const name of profileNames) {
+    const p = config.profiles[name];
+    const profilePath = expandHome(p.path);
+    if (!p.is_source) {
+      const credentialsPath = join(profilePath, adapterFor(p.cli).credentialsFile());
+      if (!existsSync(credentialsPath)) {
+        continue;
+      }
+    }
+
+    try {
+      const status = await fetchRateLimits(p, profilePath, { timeoutMs: 2000 });
+      if (status) {
+        if (status.status !== 'rate_limited' && status.fiveHourPct < 100 && status.weeklyPct < 100) {
+          return name;
+        }
+      } else {
+        // Fallback for non-oauth API profiles or missing network
+        return name;
+      }
+    } catch {
+      // best-effort
+    }
+  }
+  return null;
 }

--- a/src/core/sessionActions.ts
+++ b/src/core/sessionActions.ts
@@ -123,11 +123,18 @@ export async function resumeSession(
   config: AimuxConfig,
   profileName: string,
   sessionId: string,
-  options: { cwd?: string; forkSession?: boolean } = {},
+  options: { cwd?: string; forkSession?: boolean; attachLive?: boolean } = {},
 ): Promise<number> {
   const profile = getProfile(config, profileName);
   const adapter = adapterFor(profile.cli);
-  const rargs = adapter.resumeArgs(sessionId, { fork: options.forkSession });
+  
+  let rargs: string[];
+  if (options.attachLive && adapter.attachArgs) {
+    rargs = adapter.attachArgs(sessionId);
+  } else {
+    rargs = adapter.resumeArgs(sessionId, { fork: options.forkSession });
+  }
+
   // globalArgs() is the single overlay-injection point (e.g. codex `-p aimux`); resume
   // spawns the CLI directly (not via buildRunParams), so prepend it here.
   const args = [...adapter.globalArgs(rargs[0]), ...rargs];

--- a/src/core/symlinks.test.ts
+++ b/src/core/symlinks.test.ts
@@ -201,6 +201,30 @@ describe('syncProfile', () => {
     const entries = readdirSync(join(PROFILES_DIR, 'work'));
     expect(entries).toContain('settings.json');
   });
+
+  it('prunes orphaned and obsolete symlinks in profile', () => {
+    seedShared(['settings.json']);
+    const config = makeConfig();
+    const workDir = join(PROFILES_DIR, 'work');
+    mkdirSync(workDir, { recursive: true });
+
+    // 1. Orphaned symlink: points to expected source target, but source entry is gone
+    symlinkSync(join(SHARED_DIR, 'old-deleted.json'), join(workDir, 'old-deleted.json'));
+
+    // 2. Obsolete symlink: points to expected source target, but is now private (.credentials.json)
+    writeFileSync(join(SHARED_DIR, '.credentials.json'), 'creds');
+    symlinkSync(join(SHARED_DIR, '.credentials.json'), join(workDir, '.credentials.json'));
+
+    const result = syncProfile(config, 'work');
+
+    // Both should be pruned/unlinked and result in repaired
+    expect(result.repaired).toContain('old-deleted.json');
+    expect(result.repaired).toContain('.credentials.json');
+
+    // Verify they are physically deleted from profile so they don't block fresh creation
+    expect(existsSync(join(workDir, 'old-deleted.json'))).toBe(false);
+    expect(existsSync(join(workDir, '.credentials.json'))).toBe(false);
+  });
 });
 
 describe('syncAllProfiles', () => {
@@ -268,6 +292,17 @@ describe('checkProfileHealth', () => {
     const report = checkProfileHealth(config, 'work');
     expect(report.conflicts).toContain('settings.json');
     expect(report.valid).not.toContain('settings.json');
+  });
+
+  it('reports obsolete symlinks (now private)', () => {
+    seedShared(['settings.json', '.credentials.json']);
+    const config = makeConfig();
+    const workDir = join(PROFILES_DIR, 'work');
+    mkdirSync(workDir, { recursive: true });
+    symlinkSync(join(SHARED_DIR, '.credentials.json'), join(workDir, '.credentials.json'));
+
+    const report = checkProfileHealth(config, 'work');
+    expect(report.conflicts).toContain('.credentials.json (obsolete symlink, should be private)');
   });
 
   it('reports missing profile directory', () => {

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -311,16 +311,19 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
       continue;
     }
 
+    let success = false;
     if (existsSync(targetInProfile) || lstatExists(targetInProfile)) {
       const stat = lstatSync(targetInProfile);
       if (stat.isSymbolicLink()) {
         const linkTarget = resolve(profilePath, readlinkSync(targetInProfile));
         if (linkTarget === sourceTarget) {
           result.skipped.push(entry);
+          success = true;
         } else {
           unlinkSync(targetInProfile);
           symlinkSync(sourceTarget, targetInProfile);
           result.repaired.push(entry);
+          success = true;
         }
       } else if (adapter.reclaimsFromSource?.(entry) && stat.isFile()) {
         // A real file where a source-authoritative entry (codex's session-index DB)
@@ -330,14 +333,21 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
         unlinkSync(targetInProfile);
         symlinkSync(sourceTarget, targetInProfile);
         result.repaired.push(entry);
+        success = true;
       } else {
         result.conflicts.push(entry);
       }
     } else {
       symlinkSync(sourceTarget, targetInProfile);
       result.created.push(entry);
+      success = true;
+    }
+
+    if (success) {
+      adapter.onPostSync?.(sourcePath, entry);
     }
   }
+
 
   // Per-CLI extra symlinks (codex config overlay + plugin content) — names that do not
   // exist as source entries, so they are created beyond the readdir loop above.

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -295,7 +295,50 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     private: [],
   };
 
+  // Prune orphaned symlinks (pointing to deleted source entries)
+  // and obsolete symlinks (now private) to enable self-healing on version updates.
+  if (existsSync(profilePath)) {
+    try {
+      const profileEntries = readdirSync(profilePath);
+      for (const entry of profileEntries) {
+        const targetInProfile = join(profilePath, entry);
+        let stat;
+        try {
+          stat = lstatSync(targetInProfile);
+        } catch {
+          continue;
+        }
+        if (!stat.isSymbolicLink()) continue;
+
+        let linkTarget;
+        try {
+          linkTarget = resolve(profilePath, readlinkSync(targetInProfile));
+        } catch {
+          continue;
+        }
+        const expectedSourceTarget = join(sourcePath, entry);
+
+        if (linkTarget === expectedSourceTarget) {
+          const isShared = adapter.isShared(entry, configPrivate);
+          const sourceExists = existsSync(expectedSourceTarget);
+
+          if (!isShared || !sourceExists) {
+            try {
+              unlinkSync(targetInProfile);
+              result.repaired.push(entry);
+            } catch {
+              // ignore
+            }
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
   const sourceEntries = readdirSync(sourcePath);
+
 
   for (const entry of sourceEntries) {
     const targetInProfile = join(profilePath, entry);
@@ -451,14 +494,30 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
   }
 
   for (const entry of profileEntries) {
-    if (!adapter.isShared(entry, configPrivate)) continue;
-    if (!sourceEntries.has(entry)) {
-      const stat = lstatSync(join(profilePath, entry));
-      if (stat.isSymbolicLink()) {
-        report.orphaned.push(entry);
-      }
+    const targetInProfile = join(profilePath, entry);
+    let stat;
+    try {
+      stat = lstatSync(targetInProfile);
+    } catch {
+      continue;
+    }
+    if (!stat.isSymbolicLink()) continue;
+
+    let linkTarget;
+    try {
+      linkTarget = resolve(profilePath, readlinkSync(targetInProfile));
+    } catch {
+      continue;
+    }
+
+    if (linkTarget === join(sourcePath, entry) && !adapter.isShared(entry, configPrivate)) {
+      report.conflicts.push(`${entry} (obsolete symlink, should be private)`);
+    } else if (adapter.isShared(entry, configPrivate) && !sourceEntries.has(entry)) {
+      report.orphaned.push(entry);
     }
   }
+
+
 
   // Per-CLI extra symlinks (codex overlay + plugins). They are not source entries, so
   // they're validated here rather than in the loops above.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,11 @@ export interface ProfileConfig {
   env?: Record<string, string>;
 }
 
+export interface ProjectBinding {
+  pattern: string;
+  profile: string;
+}
+
 export interface AimuxConfig {
   version: number;
   /** Legacy single source (the claude source-of-truth). Always present for backward
@@ -19,7 +24,9 @@ export interface AimuxConfig {
   shared_sources?: Record<string, string>;
   profiles: Record<string, ProfileConfig>;
   private: string[];
+  bindings?: ProjectBinding[];
 }
+
 
 export const DEFAULT_PRIVATE_ELEMENTS = [
   '.credentials.json',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { AimuxConfig, ProfileConfig } from './config.js';
+export type { AimuxConfig, ProfileConfig, ProjectBinding } from './config.js';
 export { DEFAULT_CONFIG, DEFAULT_PRIVATE_ELEMENTS } from './config.js';
 
 export interface ProfileStatus {


### PR DESCRIPTION
This PR implements the planned features and bug fixes under the shell UX and robustness scope:

- **SQLite WAL Mode (`aimux-ylh`)**: Configured SQLite database with WAL mode on post-sync for shared Codex database instances to prevent database lockups.
- **Project-to-Profile bindings (`aimux-b0i`)**: Configured automatic selection of active profiles based on the directory path of the active project.
- **Self-Healing symlinks (`aimux-lpy`)**: Automatically detects and prunes obsolete and orphaned symlinks during version changes.
- **Prompt Indicator (`aimux-clc`)**: Implemented CLI prompt command for shell and Starship custom profile indicators.
- **Logs View and Grep (`aimux-zaj`)**: Added command to tail and grep transcripts of active and background sessions.
- **Live Session Attachment (`aimux-1uu`)**: Added support in TUI and CLI to join a live background session using native `claude attach` instead of forcing a fork copy.
- **Automatic Rate-Limit Failover (`aimux-e1i`)**: Automatically and transparently relocates active sessions to another available subscription profile when rate limits are hit.