### PR TITLE
feat: self-healing symlinks, project bindings, prompt-indicator, logs (0.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to this project are documented here. The format is based on
   subscription. Patterns support `*` and `**`; use `~/work/**` to include subdirectories
   (a bare `~/work` matches that directory only). Relative patterns are anchored to `$HOME`,
   never to the current directory, so a binding means the same thing wherever `aimux` runs.
+  Inside a bound directory a bare `aimux use` switches straight to the bound profile;
+  `aimux use --pick` forces the interactive picker.
 - **`aimux prompt-indicator`** (alias `aimux prompt`) — prints the active profile for a
   shell prompt or Starship. `--format '[aimux: %s]'` wraps it; every `%s` is substituted
   and the profile name is inserted literally.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,34 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.22.0] - 2026-07-22
+
+### Added
+- **Self-healing symlinks.** `sync` / `aimux rebuild` now prunes a profile's stale links:
+  a symlink pointing at a source entry that no longer exists (dangling), or at an entry
+  that has since become private. Previously these accumulated silently and `aimux doctor`
+  could only report them — you had to delete them by hand. Adapter-managed links (codex's
+  `aimux.config.toml` overlay and `plugins`) are exempt, since they are created by
+  `extraLinks` rather than the shared-entry loop.
+- **Project → profile bindings.** An optional `bindings` list in `config.yaml` maps a
+  directory pattern to a profile, so entering a project auto-selects the right
+  subscription. Patterns support `*` and `**`; use `~/work/**` to include subdirectories
+  (a bare `~/work` matches that directory only). Relative patterns are anchored to `$HOME`,
+  never to the current directory, so a binding means the same thing wherever `aimux` runs.
+- **`aimux prompt-indicator`** (alias `aimux prompt`) — prints the active profile for a
+  shell prompt or Starship. `--format '[aimux: %s]'` wraps it; every `%s` is substituted
+  and the profile name is inserted literally.
+- **`aimux logs [session]`** — view or grep a session transcript (`--last`, `-g <query>`),
+  for both claude and codex formats. Colors are emitted only to a TTY, so piping to a file
+  or `grep` produces clean text (also respects `NO_COLOR`).
+
+### Fixed
+- **`aimux doctor` no longer reports a healthy codex profile as broken.** codex's
+  `plugins` link is adapter-managed and deliberately outside the share allowlist; the
+  health sweep counted it as an obsolete symlink while the extraLinks check counted it as
+  valid, so the same entry appeared in both `conflicts` and `valid`, and every
+  `aimux run <codex-profile>` printed a spurious `repaired plugins`.
+
 ## [0.21.1] - 2026-06-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-threads/aimux",
-      "version": "0.21.1",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.21.1",
+  "version": "0.22.0",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1037,5 +1037,62 @@ program
     }
   });
 
+program
+  .command('logs [session]')
+  .description('View and grep chat transcripts of a session')
+  .option('--last', 'View logs of the most recent session')
+  .option('-g, --grep <query>', 'Filter transcript lines matching the query')
+  .action(async (session: string | undefined, options: { last?: boolean; grep?: string }) => {
+    try {
+      const config = requireConfig();
+      if (!session && !options.last) {
+        console.error('Error: Please specify a session ID or use --last');
+        process.exit(1);
+      }
+
+      const { unifyAllSessions } = await import('./core/unifiedSessions.js');
+      const { readTranscript } = await import('./core/handoff.js');
+      const { formatTranscript } = await import('./core/index.js');
+
+      const all = unifyAllSessions(config, { windowDays: Infinity });
+      let target: any;
+      if (options.last) {
+        target = all[0];
+      } else {
+        target = all.find(s => s.sessionId === session || s.short === session);
+      }
+
+      if (!target) {
+        console.error(`Error: Session '${session || 'last'}' not found`);
+        process.exit(1);
+      }
+
+      const raw = readTranscript(config, target);
+      if (!raw) {
+        console.error('Error: No transcript log found for this session');
+        process.exit(1);
+      }
+
+      const formatted = formatTranscript(raw);
+
+      if (options.grep) {
+        const query = options.grep.toLowerCase();
+        const matches = formatted.filter(f => f.toLowerCase().includes(query));
+        if (matches.length === 0) {
+          console.log('(No matching lines found)');
+        } else {
+          console.log(matches.join('\n\n'));
+        }
+      } else {
+        console.log(formatted.join('\n\n'));
+      }
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
 program.parse();
+
+
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,7 +10,7 @@ import {
   loadConfig, saveConfig, addProfile, removeProfile, expandHome,
   ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex, detectGemini,
   syncProfile, syncAllProfiles, checkAllProfiles,
-  launchProfile, getLastProfile, recordHistory, getProfile,
+  launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
   loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson, confirm,
@@ -207,27 +207,32 @@ program
 
       if (!profileName) {
         const cwd = process.cwd();
-        const last = getLastProfile(cwd);
-        const names = Object.keys(config.profiles);
-
-        if (names.length === 1) {
-          profileName = names[0];
+        const boundProfile = resolveProfileForDir(config, cwd);
+        if (boundProfile) {
+          profileName = boundProfile;
         } else {
-          const { render } = await import('ink');
-          const { ProfilePicker } = await import('./components/ProfilePicker.js');
-          let selectedProfile: string | undefined;
-          const { waitUntilExit } = render(
-            <ProfilePicker
-              config={config}
-              lastProfile={last}
-              onSelect={(selected: string) => {
-                selectedProfile = selected;
-              }}
-            />
-          );
-          await waitUntilExit();
-          if (!selectedProfile) return;
-          profileName = selectedProfile;
+          const last = getLastProfile(cwd);
+          const names = Object.keys(config.profiles);
+
+          if (names.length === 1) {
+            profileName = names[0];
+          } else {
+            const { render } = await import('ink');
+            const { ProfilePicker } = await import('./components/ProfilePicker.js');
+            let selectedProfile: string | undefined;
+            const { waitUntilExit } = render(
+              <ProfilePicker
+                config={config}
+                lastProfile={last}
+                onSelect={(selected: string) => {
+                  selectedProfile = selected;
+                }}
+              />
+            );
+            await waitUntilExit();
+            if (!selectedProfile) return;
+            profileName = selectedProfile;
+          }
         }
       }
 
@@ -269,24 +274,30 @@ program
 
       let profileName = profile;
       if (!profileName) {
-        const names = Object.keys(config.profiles);
-        if (names.length === 1) {
-          profileName = names[0];
+        const cwd = process.cwd();
+        const boundProfile = resolveProfileForDir(config, cwd);
+        if (boundProfile) {
+          profileName = boundProfile;
         } else {
-          const { render } = await import('ink');
-          const { ProfilePicker } = await import('./components/ProfilePicker.js');
-          const last = getLastProfile(process.cwd());
-          let selected: string | undefined;
-          // Under the shell wrapper, --export's stdout is captured by command
-          // substitution, so draw the picker on stderr (still a TTY) to keep
-          // stdout eval-clean. Direct invocation draws on stdout as usual.
-          const { waitUntilExit } = render(
-            <ProfilePicker config={config} lastProfile={last} onSelect={(s: string) => { selected = s; }} />,
-            options.export ? { stdout: process.stderr } : undefined,
-          );
-          await waitUntilExit();
-          if (!selected) return;
-          profileName = selected;
+          const names = Object.keys(config.profiles);
+          if (names.length === 1) {
+            profileName = names[0];
+          } else {
+            const { render } = await import('ink');
+            const { ProfilePicker } = await import('./components/ProfilePicker.js');
+            const last = getLastProfile(cwd);
+            let selected: string | undefined;
+            // Under the shell wrapper, --export's stdout is captured by command
+            // substitution, so draw the picker on stderr (still a TTY) to keep
+            // stdout eval-clean. Direct invocation draws on stdout as usual.
+            const { waitUntilExit } = render(
+              <ProfilePicker config={config} lastProfile={last} onSelect={(s: string) => { selected = s; }} />,
+              options.export ? { stdout: process.stderr } : undefined,
+            );
+            await waitUntilExit();
+            if (!selected) return;
+            profileName = selected;
+          }
         }
       }
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -10,7 +10,7 @@ import {
   loadConfig, saveConfig, addProfile, removeProfile, expandHome,
   ensureProfileDir, initAutoDetect, initFromSource, detectClaudeDirs, detectCodex, detectGemini,
   syncProfile, syncAllProfiles, checkAllProfiles,
-  launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile,
+  launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile, loadActiveProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
   loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson, confirm,
@@ -937,7 +937,7 @@ program
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  commands="init run status usage profile rebuild doctor auth completions"
+  commands="init run status usage profile rebuild doctor auth prompt-indicator prompt completions"
 
   case "\${prev}" in
     run|auth)
@@ -957,7 +957,7 @@ complete -F _aimux aimux
       console.log(`#compdef aimux
 _aimux() {
   local -a commands profiles
-  commands=(init run status usage profile rebuild doctor auth completions)
+  commands=(init run status usage profile rebuild doctor auth prompt-indicator prompt completions)
   profiles=(${profiles})
 
   _arguments '1:command:($commands)' '*::arg:->args'
@@ -974,7 +974,7 @@ _aimux() {
 _aimux
 # Add to ~/.zshrc: eval "$(aimux completions zsh)"`);
     } else if (shell === 'fish') {
-      console.log(`complete -c aimux -n '__fish_use_subcommand' -a 'init run status usage profile rebuild doctor auth completions'
+      console.log(`complete -c aimux -n '__fish_use_subcommand' -a 'init run status usage profile rebuild doctor auth prompt-indicator prompt completions'
 complete -c aimux -n '__fish_seen_subcommand_from run' -a '${profiles}'
 complete -c aimux -n '__fish_seen_subcommand_from profile' -a 'add list update remove clone'
 complete -c aimux -n '__fish_seen_subcommand_from auth' -a 'login status'
@@ -1018,4 +1018,24 @@ program
     console.log(`\nReload with: source ${rcFile}`);
   });
 
+program
+  .command('prompt-indicator')
+  .alias('prompt')
+  .description('Print the active profile name (for zsh/bash/Starship prompt)')
+  .option('-f, --format <pattern>', 'Format pattern (e.g. "[aimux: %s]"). If omitted, outputs raw profile name.')
+  .action((options: { format?: string }) => {
+    try {
+      const active = process.env.AIMUX_PROFILE || loadActiveProfile();
+      if (!active) return;
+      if (options.format) {
+        console.log(options.format.replace('%s', active));
+      } else {
+        console.log(active);
+      }
+    } catch {
+      // fail silently so shell prompts do not break/spew errors
+    }
+  });
+
 program.parse();
+

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -937,7 +937,7 @@ program
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
   prev="\${COMP_WORDS[COMP_CWORD-1]}"
-  commands="init run status usage profile rebuild doctor auth prompt-indicator prompt completions"
+  commands="init run status usage profile rebuild doctor auth logs prompt-indicator prompt completions"
 
   case "\${prev}" in
     run|auth)
@@ -957,7 +957,7 @@ complete -F _aimux aimux
       console.log(`#compdef aimux
 _aimux() {
   local -a commands profiles
-  commands=(init run status usage profile rebuild doctor auth prompt-indicator prompt completions)
+  commands=(init run status usage profile rebuild doctor auth logs prompt-indicator prompt completions)
   profiles=(${profiles})
 
   _arguments '1:command:($commands)' '*::arg:->args'
@@ -974,7 +974,7 @@ _aimux() {
 _aimux
 # Add to ~/.zshrc: eval "$(aimux completions zsh)"`);
     } else if (shell === 'fish') {
-      console.log(`complete -c aimux -n '__fish_use_subcommand' -a 'init run status usage profile rebuild doctor auth prompt-indicator prompt completions'
+      console.log(`complete -c aimux -n '__fish_use_subcommand' -a 'init run status usage profile rebuild doctor auth logs prompt-indicator prompt completions'
 complete -c aimux -n '__fish_seen_subcommand_from run' -a '${profiles}'
 complete -c aimux -n '__fish_seen_subcommand_from profile' -a 'add list update remove clone'
 complete -c aimux -n '__fish_seen_subcommand_from auth' -a 'login status'
@@ -1028,7 +1028,10 @@ program
       const active = process.env.AIMUX_PROFILE || loadActiveProfile();
       if (!active) return;
       if (options.format) {
-        console.log(options.format.replace('%s', active));
+        // replaceAll + function replacer: substitutes EVERY `%s`, and the profile name is
+        // inserted literally (a bare `replace` would treat `$&`/`` $` `` in a name as
+        // replacement patterns).
+        console.log(options.format.replaceAll('%s', () => active));
       } else {
         console.log(active);
       }
@@ -1073,7 +1076,9 @@ program
         process.exit(1);
       }
 
-      const formatted = formatTranscript(raw);
+      const formatted = formatTranscript(raw, {
+        color: Boolean(process.stdout.isTTY) && !process.env.NO_COLOR,
+      });
 
       if (options.grep) {
         const query = options.grep.toLowerCase();

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -266,7 +266,8 @@ program
   .description('Switch the current shell to a profile (persistent until you switch again)')
   .option('--export', 'Emit shell export statements for eval (used by the shell wrapper)')
   .option('--shell <shell>', 'Target shell for --export: bash, zsh, or fish')
-  .action(async (profile: string | undefined, options: { export?: boolean; shell?: string }) => {
+  .option('--pick', 'Always show the profile picker, ignoring any directory binding')
+  .action(async (profile: string | undefined, options: { export?: boolean; shell?: string; pick?: boolean }) => {
     try {
       const config = requireConfig();
 
@@ -275,7 +276,9 @@ program
       let profileName = profile;
       if (!profileName) {
         const cwd = process.cwd();
-        const boundProfile = resolveProfileForDir(config, cwd);
+        // A binding auto-selects the profile for this directory; --pick opts back into
+        // the interactive picker so `aimux use` never becomes un-overridable.
+        const boundProfile = options.pick ? null : resolveProfileForDir(config, cwd);
         if (boundProfile) {
           profileName = boundProfile;
         } else {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { tmpdir, homedir } from 'node:os';
 import { setAimuxDir } from './paths.js';
 import {
   validateConfig,
@@ -185,6 +185,20 @@ describe('matchGlob', () => {
   it('matches exact paths', () => {
     expect(matchGlob('/home/user/work', '/home/user/work')).toBe(true);
     expect(matchGlob('/home/user/work', '/home/user/other')).toBe(false);
+  });
+
+  it('anchors a relative pattern to $HOME, not to process.cwd()', () => {
+    // Regression: `resolve(pattern)` used the CWD, so the same binding in config.yaml
+    // matched different directories depending on where `aimux` happened to be run.
+    const home = homedir();
+    const original = process.cwd();
+    try {
+      process.chdir(tmpdir());
+      expect(matchGlob(join(home, 'work', 'proj'), 'work/**')).toBe(true);
+      expect(matchGlob(join(tmpdir(), 'work', 'proj'), 'work/**')).toBe(false);
+    } finally {
+      process.chdir(original);
+    }
   });
 
   it('matches segments using *', () => {

--- a/src/core/config.test.ts
+++ b/src/core/config.test.ts
@@ -14,6 +14,8 @@ import {
   loadConfig,
   recordHistory,
   getLastProfile,
+  matchGlob,
+  resolveProfileForDir,
 } from './config.js';
 
 const TEST_DIR = join(tmpdir(), `aimux-test-${Date.now()}`);
@@ -150,3 +152,66 @@ describe('history', () => {
     expect(getLastProfile('/home/user/project-a')).toBe('own');
   });
 });
+
+describe('bindings config validation', () => {
+  it('validates bindings array structure', () => {
+    const config = createDefaultConfig('~/.claude');
+    expect(validateConfig(config)).toHaveLength(0);
+
+    // invalid type for bindings
+    const badConfig1 = { ...config, bindings: 'not-an-array' };
+    expect(validateConfig(badConfig1)).toContain('bindings must be an array of objects');
+
+    // non-object elements
+    const badConfig2 = { ...config, bindings: ['string'] };
+    expect(validateConfig(badConfig2)).toContain('bindings[0] must be an object');
+
+    // missing fields
+    const badConfig3 = { ...config, bindings: [{}] };
+    expect(validateConfig(badConfig3)).toContain('bindings[0]: pattern must be a non-empty string');
+    expect(validateConfig(badConfig3)).toContain('bindings[0]: profile must be a non-empty string');
+
+    // non-existent profile
+    const badConfig4 = { ...config, bindings: [{ pattern: '~/work/**', profile: 'non-existent' }] };
+    expect(validateConfig(badConfig4)).toContain("bindings[0]: profile 'non-existent' does not exist in profiles");
+
+    // valid binding
+    const goodConfig = { ...config, bindings: [{ pattern: '~/work/**', profile: 'main' }] };
+    expect(validateConfig(goodConfig)).toHaveLength(0);
+  });
+});
+
+describe('matchGlob', () => {
+  it('matches exact paths', () => {
+    expect(matchGlob('/home/user/work', '/home/user/work')).toBe(true);
+    expect(matchGlob('/home/user/work', '/home/user/other')).toBe(false);
+  });
+
+  it('matches segments using *', () => {
+    expect(matchGlob('/home/user/work/project', '/home/user/*/project')).toBe(true);
+    expect(matchGlob('/home/user/work/project', '/home/user/work/*')).toBe(true);
+    expect(matchGlob('/home/user/work/project', '/home/user/*')).toBe(false);
+  });
+
+  it('matches recursively using **', () => {
+    expect(matchGlob('/home/user/work/project/src/index.ts', '/home/user/work/**')).toBe(true);
+    expect(matchGlob('/home/user/work', '/home/user/work/**')).toBe(true);
+    expect(matchGlob('/home/user/other', '/home/user/work/**')).toBe(false);
+  });
+});
+
+describe('resolveProfileForDir', () => {
+  it('resolves bound profile when pattern matches', () => {
+    let config = createDefaultConfig('~/.claude');
+    config = addProfile(config, 'work', { model: 'opus-4-6' });
+    config.bindings = [
+      { pattern: '~/work/project1/**', profile: 'work' },
+      { pattern: '~/personal/**', profile: 'main' }
+    ];
+
+    expect(resolveProfileForDir(config, '~/work/project1/src')).toBe('work');
+    expect(resolveProfileForDir(config, '~/personal/dev')).toBe('main');
+    expect(resolveProfileForDir(config, '~/other')).toBeNull();
+  });
+});
+

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,9 +1,11 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { resolve, sep } from 'node:path';
 import { parse, stringify } from 'yaml';
 import type { AimuxConfig, ProfileConfig, HistoryEntry } from '../types/index.js';
 import { DEFAULT_CONFIG, DEFAULT_PRIVATE_ELEMENTS } from '../types/index.js';
 import { getConfigPath, getHistoryPath, getAimuxDir, getProfilesDir, expandHome } from './paths.js';
 import { adapterFor } from './adapters/index.js';
+
 
 export function loadConfig(): AimuxConfig | null {
   const configPath = getConfigPath();
@@ -184,8 +186,32 @@ export function validateConfig(config: unknown): string[] {
     errors.push('private must be an array of strings');
   }
 
+  if (c.bindings !== undefined) {
+    if (!Array.isArray(c.bindings)) {
+      errors.push('bindings must be an array of objects');
+    } else {
+      const profiles = (c.profiles || {}) as Record<string, unknown>;
+      for (let i = 0; i < c.bindings.length; i++) {
+        const b = c.bindings[i];
+        if (!b || typeof b !== 'object' || Array.isArray(b)) {
+          errors.push(`bindings[${i}] must be an object`);
+          continue;
+        }
+        if (typeof b.pattern !== 'string' || !b.pattern) {
+          errors.push(`bindings[${i}]: pattern must be a non-empty string`);
+        }
+        if (typeof b.profile !== 'string' || !b.profile) {
+          errors.push(`bindings[${i}]: profile must be a non-empty string`);
+        } else if (!profiles[b.profile]) {
+          errors.push(`bindings[${i}]: profile '${b.profile}' does not exist in profiles`);
+        }
+      }
+    }
+  }
+
   return errors;
 }
+
 
 // --- History ---
 
@@ -222,6 +248,75 @@ export function getLastProfile(dir: string): string | null {
   const entry = entries.find(e => e.dir === dir);
   return entry?.profile ?? null;
 }
+
+export function matchGlob(dir: string, pattern: string): boolean {
+  const cleanDir = resolve(expandHome(dir));
+  const cleanPattern = resolve(expandHome(pattern));
+
+  if (cleanDir === cleanPattern) return true;
+
+  const dirParts = cleanDir.split(sep);
+  const patternParts = cleanPattern.split(sep);
+
+  let d = 0;
+  let p = 0;
+  while (d < dirParts.length && p < patternParts.length) {
+    const part = patternParts[p];
+    if (part === '**') {
+      if (p === patternParts.length - 1) {
+        return true;
+      }
+      const nextPatternPart = patternParts[p + 1];
+      let found = false;
+      while (d < dirParts.length) {
+        if (matchSegment(dirParts[d], nextPatternPart)) {
+          found = true;
+          break;
+        }
+        d++;
+      }
+      if (!found) return false;
+      p += 2;
+      d++;
+      continue;
+    }
+
+    if (!matchSegment(dirParts[d], part)) {
+      return false;
+    }
+    d++;
+    p++;
+  }
+
+  if (d === dirParts.length && p === patternParts.length - 1 && patternParts[p] === '**') {
+    return true;
+  }
+
+  return d === dirParts.length && p === patternParts.length;
+}
+
+function matchSegment(segment: string, pattern: string): boolean {
+  if (pattern === '*') return true;
+  const regexStr = '^' + pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.') + '$';
+  const regex = new RegExp(regexStr);
+  return regex.test(segment);
+}
+
+export function resolveProfileForDir(config: AimuxConfig, dir: string): string | null {
+  if (config.bindings && config.bindings.length > 0) {
+    for (const binding of config.bindings) {
+      if (matchGlob(dir, binding.pattern) && config.profiles[binding.profile]) {
+        return binding.profile;
+      }
+    }
+  }
+  return null;
+}
+
+
 
 // --- Filesystem ---
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { resolve, sep } from 'node:path';
+import { resolve, sep, isAbsolute } from 'node:path';
+import { homedir } from 'node:os';
 import { parse, stringify } from 'yaml';
 import type { AimuxConfig, ProfileConfig, HistoryEntry } from '../types/index.js';
 import { DEFAULT_CONFIG, DEFAULT_PRIVATE_ELEMENTS } from '../types/index.js';
@@ -251,7 +252,12 @@ export function getLastProfile(dir: string): string | null {
 
 export function matchGlob(dir: string, pattern: string): boolean {
   const cleanDir = resolve(expandHome(dir));
-  const cleanPattern = resolve(expandHome(pattern));
+  // Anchor a relative pattern to $HOME, never to process.cwd(): a binding in config.yaml
+  // must mean the same directory no matter where `aimux` was invoked from. Test the RAW
+  // pattern — expandHome() already resolves a bare relative path against the cwd.
+  const cleanPattern = pattern.startsWith('~/') || isAbsolute(pattern)
+    ? expandHome(pattern)
+    : resolve(homedir(), pattern);
 
   if (cleanDir === cleanPattern) return true;
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -12,10 +12,12 @@ export {
   saveHistory,
   recordHistory,
   getLastProfile,
+  resolveProfileForDir,
   configExists,
   ensureAimuxDir,
   ensureProfileDir,
 } from './config.js';
+
 
 export {
   expandHome,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -92,3 +92,6 @@ export { handoffSession, buildHandoffPrompt, buildSummarizePrompt, readTranscrip
 export type { HandoffDeps, HandoffResult } from './handoff.js';
 
 export { loadActiveProfile, saveActiveProfile, getActiveProfilePath } from './activeProfile.js';
+
+export { formatTranscript } from './logs.js';
+

--- a/src/core/logs.test.ts
+++ b/src/core/logs.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { formatTranscript } from './logs.js';
+
+describe('formatTranscript', () => {
+  it('formats Claude user and assistant messages', () => {
+    const raw = [
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+      JSON.stringify({ type: 'assistant', message: { role: 'assistant', content: [{ text: 'hi there' }] } }),
+    ].join('\n');
+
+    const formatted = formatTranscript(raw);
+    expect(formatted).toHaveLength(2);
+    expect(formatted[0]).toContain('[User]');
+    expect(formatted[0]).toContain('hello');
+    expect(formatted[1]).toContain('[Assistant]');
+    expect(formatted[1]).toContain('hi there');
+  });
+
+  it('formats Codex session meta and response items', () => {
+    const raw = [
+      JSON.stringify({ type: 'session_meta', payload: { cwd: '/home/user/project' } }),
+      JSON.stringify({ type: 'response_item', payload: { role: 'user', content: 'tell me a joke' } }),
+      JSON.stringify({ type: 'response_item', payload: { role: 'assistant', content: ['joke response'] } }),
+    ].join('\n');
+
+    const formatted = formatTranscript(raw);
+    expect(formatted).toHaveLength(3);
+    expect(formatted[0]).toContain('[CWD]');
+    expect(formatted[0]).toContain('/home/user/project');
+    expect(formatted[1]).toContain('[User]');
+    expect(formatted[1]).toContain('tell me a joke');
+    expect(formatted[2]).toContain('[Assistant]');
+    expect(formatted[2]).toContain('joke response');
+  });
+
+  it('emits no ANSI escapes when color is off (piping `aimux logs` to a file or grep)', () => {
+    const raw = [
+      JSON.stringify({ type: 'session_meta', payload: { cwd: '/home/user/project' } }),
+      JSON.stringify({ type: 'user', message: { role: 'user', content: 'hello' } }),
+    ].join('\n');
+
+    const plain = formatTranscript(raw, { color: false });
+    expect(plain.join('\n')).not.toContain('\x1b[');
+    // content is still there, just uncolored
+    expect(plain[0]).toContain('[CWD]');
+    expect(plain[1]).toContain('[User]');
+    expect(plain[1]).toContain('hello');
+
+    // default stays colored for interactive use
+    expect(formatTranscript(raw).join('\n')).toContain('\x1b[');
+  });
+});

--- a/src/core/logs.ts
+++ b/src/core/logs.ts
@@ -1,0 +1,69 @@
+export function extractText(content: any): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c: any) => {
+        if (typeof c === 'string') return c;
+        if (c && typeof c === 'object' && typeof c.text === 'string') return c.text;
+        return '';
+      })
+      .filter(Boolean)
+      .join(' ');
+  }
+  return '';
+}
+
+export function contentText(content: any): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part: any) => (typeof part === 'string' ? part : typeof part?.text === 'string' ? part.text : ''))
+      .join('')
+      .trim();
+  }
+  return '';
+}
+
+/** Render a raw JSONL transcript as `[Role] text` lines (claude + codex formats).
+ *  `color` adds ANSI codes — pass false when stdout is not a TTY, otherwise piping
+ *  `aimux logs` into a file or grep embeds escape sequences in the output. */
+export function formatTranscript(rawTranscript: string, opts: { color?: boolean } = {}): string[] {
+  const color = opts.color ?? true;
+  const paint = (code: string, s: string) => (color ? `${code}${s}\x1b[0m` : s);
+  const lines = rawTranscript.split('\n');
+  const formatted: string[] = [];
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    try {
+      const obj = JSON.parse(line);
+      let role = '';
+      let text = '';
+
+      // Claude Format
+      if (obj.type === 'user' && obj.message?.role === 'user') {
+        role = 'User';
+        text = extractText(obj.message.content);
+      } else if (obj.type === 'assistant' && obj.message?.role === 'assistant') {
+        role = 'Assistant';
+        text = extractText(obj.message.content);
+      }
+      // Codex Format
+      else if (obj.type === 'response_item') {
+        role = obj.payload?.role === 'user' ? 'User' : 'Assistant';
+        text = contentText(obj.payload?.content);
+      } else if (obj.type === 'session_meta' && obj.payload?.cwd) {
+        formatted.push(`${paint('\x1b[90m', '[CWD]')} ${obj.payload.cwd}`);
+        continue;
+      }
+
+      if (role && text.trim()) {
+        formatted.push(`${paint(role === 'User' ? '\x1b[32m' : '\x1b[36m', `[${role}]`)} ${text.trim()}`);
+      }
+    } catch {
+      // ignore parsing error for malformed lines
+    }
+  }
+
+  return formatted;
+}

--- a/src/core/symlinks.test.ts
+++ b/src/core/symlinks.test.ts
@@ -80,6 +80,38 @@ describe('syncProfile reclaims codex session-index DB', () => {
     expect(result.private).toContain('auth.json');
   });
 
+  it('leaves adapter-managed links (codex overlay + plugins) alone: not pruned, not a conflict', () => {
+    // Regression: the self-healing prune matches on `linkTarget === source/<entry>`, which
+    // codex's extraLinks (`plugins`, `aimux.config.toml`) satisfy — but they are NOT in the
+    // codex share allowlist. Without an exemption every sync unlinks + recreates them
+    // ("repaired plugins" on every run) and `doctor` reports a healthy profile as broken.
+    const codexSrc = join(TEST_DIR, 'codex-src-extra');
+    const profileDir = join(PROFILES_DIR, 'cxextra');
+    mkdirSync(join(codexSrc, 'plugins'), { recursive: true });
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(join(codexSrc, 'config.toml'), 'model = "x"');
+
+    const config = makeConfig({
+      shared_sources: { codex: codexSrc },
+      profiles: {
+        main: { cli: 'claude', path: SHARED_DIR, is_source: true },
+        cxextra: { cli: 'codex', path: profileDir },
+      },
+    });
+
+    syncProfile(config, 'cxextra');
+    // Second sync must be a no-op for the adapter links — nothing churned.
+    const again = syncProfile(config, 'cxextra');
+    expect(again.repaired).not.toContain('plugins');
+    expect(again.repaired).not.toContain('aimux.config.toml');
+    expect(existsSync(join(profileDir, 'plugins'))).toBe(true);
+
+    const health = checkProfileHealth(config, 'cxextra');
+    expect(health.conflicts.join(' ')).not.toContain('plugins');
+    expect(health.valid).toContain('plugins');
+    expect(health.valid).toContain('aimux.config.toml');
+  });
+
   it('does NOT reclaim a directory at the entry path — falls through to conflicts (no EISDIR)', () => {
     const codexSrc = join(TEST_DIR, 'codex-src-dir');
     const profileDir = join(PROFILES_DIR, 'cxdir');

--- a/src/core/symlinks.test.ts
+++ b/src/core/symlinks.test.ts
@@ -201,6 +201,30 @@ describe('syncProfile', () => {
     const entries = readdirSync(join(PROFILES_DIR, 'work'));
     expect(entries).toContain('settings.json');
   });
+
+  it('prunes orphaned and obsolete symlinks in profile', () => {
+    seedShared(['settings.json']);
+    const config = makeConfig();
+    const workDir = join(PROFILES_DIR, 'work');
+    mkdirSync(workDir, { recursive: true });
+
+    // 1. Orphaned symlink: points to expected source target, but source entry is gone
+    symlinkSync(join(SHARED_DIR, 'old-deleted.json'), join(workDir, 'old-deleted.json'));
+
+    // 2. Obsolete symlink: points to expected source target, but is now private (.credentials.json)
+    writeFileSync(join(SHARED_DIR, '.credentials.json'), 'creds');
+    symlinkSync(join(SHARED_DIR, '.credentials.json'), join(workDir, '.credentials.json'));
+
+    const result = syncProfile(config, 'work');
+
+    // Both should be pruned/unlinked and result in repaired
+    expect(result.repaired).toContain('old-deleted.json');
+    expect(result.repaired).toContain('.credentials.json');
+
+    // Verify they are physically deleted from profile so they don't block fresh creation
+    expect(existsSync(join(workDir, 'old-deleted.json'))).toBe(false);
+    expect(existsSync(join(workDir, '.credentials.json'))).toBe(false);
+  });
 });
 
 describe('syncAllProfiles', () => {
@@ -268,6 +292,17 @@ describe('checkProfileHealth', () => {
     const report = checkProfileHealth(config, 'work');
     expect(report.conflicts).toContain('settings.json');
     expect(report.valid).not.toContain('settings.json');
+  });
+
+  it('reports obsolete symlinks (now private)', () => {
+    seedShared(['settings.json', '.credentials.json']);
+    const config = makeConfig();
+    const workDir = join(PROFILES_DIR, 'work');
+    mkdirSync(workDir, { recursive: true });
+    symlinkSync(join(SHARED_DIR, '.credentials.json'), join(workDir, '.credentials.json'));
+
+    const report = checkProfileHealth(config, 'work');
+    expect(report.conflicts).toContain('.credentials.json (obsolete symlink, should be private)');
   });
 
   it('reports missing profile directory', () => {

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -295,12 +295,20 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     private: [],
   };
 
+  // Adapter-managed links (codex's `aimux.config.toml` overlay + `plugins`) are created
+  // by extraLinks, NOT by the shared-entry loop, so they are deliberately absent from
+  // `isShared`. Exempt them from the prune/health sweeps below — otherwise every sync
+  // unlinks and recreates them (spurious "repaired") and `doctor` reports a healthy
+  // codex profile as broken.
+  const adapterLinkNames = new Set(adapter.extraLinks(sourcePath).map((l) => l.link));
+
   // Prune orphaned symlinks (pointing to deleted source entries)
   // and obsolete symlinks (now private) to enable self-healing on version updates.
   if (existsSync(profilePath)) {
     try {
       const profileEntries = readdirSync(profilePath);
       for (const entry of profileEntries) {
+        if (adapterLinkNames.has(entry)) continue;
         const targetInProfile = join(profilePath, entry);
         let stat;
         try {
@@ -483,7 +491,12 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
     }
   }
 
+  // Adapter-managed links are validated by the extraLinks loop below; skip them here so
+  // they are not double-reported as both `conflicts` and `valid`.
+  const adapterLinkNames = new Set(adapter.extraLinks(sourcePath).map((l) => l.link));
+
   for (const entry of profileEntries) {
+    if (adapterLinkNames.has(entry)) continue;
     const targetInProfile = join(profilePath, entry);
     let stat;
     try {

--- a/src/core/symlinks.ts
+++ b/src/core/symlinks.ts
@@ -295,7 +295,50 @@ export function syncProfile(config: AimuxConfig, profileName: string): SyncResul
     private: [],
   };
 
+  // Prune orphaned symlinks (pointing to deleted source entries)
+  // and obsolete symlinks (now private) to enable self-healing on version updates.
+  if (existsSync(profilePath)) {
+    try {
+      const profileEntries = readdirSync(profilePath);
+      for (const entry of profileEntries) {
+        const targetInProfile = join(profilePath, entry);
+        let stat;
+        try {
+          stat = lstatSync(targetInProfile);
+        } catch {
+          continue;
+        }
+        if (!stat.isSymbolicLink()) continue;
+
+        let linkTarget;
+        try {
+          linkTarget = resolve(profilePath, readlinkSync(targetInProfile));
+        } catch {
+          continue;
+        }
+        const expectedSourceTarget = join(sourcePath, entry);
+
+        if (linkTarget === expectedSourceTarget) {
+          const isShared = adapter.isShared(entry, configPrivate);
+          const sourceExists = existsSync(expectedSourceTarget);
+
+          if (!isShared || !sourceExists) {
+            try {
+              unlinkSync(targetInProfile);
+              result.repaired.push(entry);
+            } catch {
+              // ignore
+            }
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
   const sourceEntries = readdirSync(sourcePath);
+
 
   for (const entry of sourceEntries) {
     const targetInProfile = join(profilePath, entry);
@@ -441,14 +484,30 @@ export function checkProfileHealth(config: AimuxConfig, profileName: string): He
   }
 
   for (const entry of profileEntries) {
-    if (!adapter.isShared(entry, configPrivate)) continue;
-    if (!sourceEntries.has(entry)) {
-      const stat = lstatSync(join(profilePath, entry));
-      if (stat.isSymbolicLink()) {
-        report.orphaned.push(entry);
-      }
+    const targetInProfile = join(profilePath, entry);
+    let stat;
+    try {
+      stat = lstatSync(targetInProfile);
+    } catch {
+      continue;
+    }
+    if (!stat.isSymbolicLink()) continue;
+
+    let linkTarget;
+    try {
+      linkTarget = resolve(profilePath, readlinkSync(targetInProfile));
+    } catch {
+      continue;
+    }
+
+    if (linkTarget === join(sourcePath, entry) && !adapter.isShared(entry, configPrivate)) {
+      report.conflicts.push(`${entry} (obsolete symlink, should be private)`);
+    } else if (adapter.isShared(entry, configPrivate) && !sourceEntries.has(entry)) {
+      report.orphaned.push(entry);
     }
   }
+
+
 
   // Per-CLI extra symlinks (codex overlay + plugins). They are not source entries, so
   // they're validated here rather than in the loops above.

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -9,6 +9,11 @@ export interface ProfileConfig {
   env?: Record<string, string>;
 }
 
+export interface ProjectBinding {
+  pattern: string;
+  profile: string;
+}
+
 export interface AimuxConfig {
   version: number;
   /** Legacy single source (the claude source-of-truth). Always present for backward
@@ -19,7 +24,9 @@ export interface AimuxConfig {
   shared_sources?: Record<string, string>;
   profiles: Record<string, ProfileConfig>;
   private: string[];
+  bindings?: ProjectBinding[];
 }
+
 
 export const DEFAULT_PRIVATE_ELEMENTS = [
   '.credentials.json',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { AimuxConfig, ProfileConfig } from './config.js';
+export type { AimuxConfig, ProfileConfig, ProjectBinding } from './config.js';
 export { DEFAULT_CONFIG, DEFAULT_PRIVATE_ELEMENTS } from './config.js';
 
 export interface ProfileStatus {


### PR DESCRIPTION
Ships the reviewable, verified subset of the shell-UX work from #22. Each feature was rebuilt on current `master` and checked against real profiles on a live machine.

## What's in

**Self-healing symlinks.** `sync` / `aimux rebuild` now prunes a profile's stale links — a symlink pointing at a source entry that no longer exists, or at an entry that has since become private. Before this they piled up silently and `aimux doctor` could only report them; you had to delete them by hand.

**Project → profile bindings.** An optional `bindings` list in `config.yaml` maps a directory pattern to a profile, so entering a project selects the right subscription. `*` and `**` are supported — use `~/work/**` to include subdirectories, since a bare `~/work` matches only that directory. Relative patterns anchor to `$HOME`, never `process.cwd()`, so a binding means the same directory wherever `aimux` is run from.

**`aimux prompt-indicator`** (alias `prompt`) — prints the active profile for a shell prompt or Starship. `--format '[aimux: %s]'` wraps it; every `%s` is substituted and the name is inserted literally.

**`aimux logs [session]`** — view or grep a session transcript (`--last`, `-g <query>`) for both claude and codex formats. Colors go only to a TTY, so piping to a file or `grep` gives clean text; `NO_COLOR` is respected.

## Bug fixed along the way

`aimux doctor` reported a **healthy codex profile as broken**. codex's `plugins` link is adapter-managed (created by `extraLinks`) and deliberately outside the codex share allowlist, but the prune loop matched it anyway. Result: every sync unlinked and recreated it — a spurious `repaired plugins` on every `aimux run <codex-profile>` — and the health sweep listed the same entry as both a `conflict` and `valid`. Adapter-managed links are now exempt from both sweeps.

## Deliberately left out of #22, and why

- **SQLite WAL pragma** — a no-op. The session-index DB is a symlink to the source DB that codex already keeps in WAL, and the code shelled out to an undeclared `sqlite3` binary whose absence was indistinguishable from success (`spawnSync` returns `{error}` rather than throwing, and the result was never checked).
- **`claude attach`** — no such subcommand exists (checked against claude 2.1.217). The TUI made it the default action for Enter on a live background session, so the most common interaction returned exit code 1.
- **Rate-limit auto-failover** — it decided a rate limit had occurred by substring-matching the model's own reply for `"429"` / `"rate limit"` / `"overloaded"`, with no loop bound and no CLI filter on the target profile. Asking about HTTP 429 handling would bounce a session between subscriptions indefinitely, each hop a billed turn. This needs a redesign against the real stream protocol, not a patch.

Also note: #22 could not be built at all — `src/core/index.ts` exported `./logs.js`, but `logs.ts` was never committed (it existed only as an untracked file locally, which is why tests looked green). Those files are included here.

## Verification

- **305 tests pass**, `tsc` clean. The codex `plugins` regression test was confirmed to fail without the fix (`expected [ 'plugins' ] to not include 'plugins'`) and pass with it.
- The bindings test caught a real mistake in my first attempt: `expandHome()` already resolves a bare relative path against the cwd, so the initial `isAbsolute` guard never fired. Fixed by testing the raw pattern.
- **On real profiles:** `aimux doctor` now reports all four healthy — the self-healing pruned two genuinely dangling links (`plans`, `tasks`) that had been stale since April. `aimux rebuild` of a codex profile is idempotent (`repaired: 0` on repeat runs). `aimux logs --last | grep` emits zero escape codes.

Bumps **0.21.1 → 0.22.0**.