### PR TITLE
fix: stop claude re-prompting for login on a freshly created profile (0.22.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 [Semantic Versioning](https://semver.org/).
 
+## [0.22.1] - 2026-07-22
+
+### Fixed
+- **A new claude profile asked for login again right after `aimux auth login` succeeded.**
+  The credentials were never the problem — a freshly created profile dir has no
+  `.claude.json`, so `hasCompletedOnboarding` is unset and claude opens its first-run
+  wizard on the next `aimux run`. The wizard includes an account step, which reads as
+  "my login was lost". `aimux profile add` now seeds the onboarding flag for every claude
+  profile, not just `--api` ones (the seed already existed but was wired only to the API
+  path). Existing profiles self-heal: `aimux auth login` seeds it after a successful
+  login, and `aimux run` seeds it for a profile that already has credentials — gated on
+  credentials being present, so an unauthenticated profile still gets its real login
+  prompt. An existing `.claude.json` is never overwritten.
+  - `seedApiClaudeJson` is renamed to `seedClaudeOnboarding`; the old name stays exported
+    as a deprecated alias for `./core` consumers.
+
 ## [0.22.0] - 2026-07-22
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-threads/aimux",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digital-threads/aimux",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Local AI workspace orchestrator — manage multiple AI CLI subscriptions with shared knowledge and isolated auth",
   "type": "module",
   "bin": {

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -13,7 +13,7 @@ import {
   launchProfile, getLastProfile, resolveProfileForDir, recordHistory, getProfile, loadActiveProfile,
   looksLikeSubcommand, adapterFor,
   summarizeUsage, parseSinceDuration, totalTokens,
-  loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedApiClaudeJson, confirm,
+  loadProfileEnv, collectApiCredentials, collectProviderCredentials, PROVIDER_PRESETS, writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, seedClaudeOnboarding, confirm,
   parseShell, buildSwitchEnv, renderShellExports, renderShellInit,
 } from './core/index.js';
 
@@ -249,6 +249,20 @@ program
       if (!launchingSubcommand) {
         recordHistory(process.cwd(), profileName);
       }
+
+      // Self-heal profiles created before the onboarding seed existed: an AUTHENTICATED
+      // claude profile with no `.claude.json` hits claude's first-run wizard and is asked
+      // for an account again. Gated on credentials being present so a genuinely
+      // unauthenticated profile still gets its real login prompt.
+      {
+        const p = config.profiles[profileName];
+        const pPath = expandHome(p.path);
+        if (p.cli === 'claude' && !p.is_source
+            && existsSync(join(pPath, adapterFor(p.cli).credentialsFile()))) {
+          seedClaudeOnboarding(pPath);
+        }
+      }
+
       const permWarning = checkDotenvPermissions(expandHome(config.profiles[profileName].path));
       if (permWarning) {
         console.error(`\x1b[33m⚠ ${permWarning}\x1b[0m`);
@@ -629,12 +643,17 @@ program
             console.log(`  conflicts left unchanged: ${sync.conflicts.join(', ')}`);
           }
 
+          // Every claude profile needs the onboarding flag, not just API ones: without it
+          // `aimux run` opens claude's first-run wizard (account step included), which
+          // looks like the login was lost even though `aimux auth login` succeeded.
+          const isClaudeProfile = (options.cli ?? 'claude') === 'claude';
+          if (isClaudeProfile && seedClaudeOnboarding(profilePath)) {
+            console.log('  Seeded .claude.json (skips Claude Code onboarding)');
+          }
+
           if (apiVars) {
             writeProfileDotEnv(profilePath, apiVars);
             console.log(`  Credentials saved to ${join(profilePath, '.env')} (chmod 600)`);
-            if (seedApiClaudeJson(profilePath)) {
-              console.log('  Seeded .claude.json (skips Claude Code onboarding)');
-            }
             console.log(`  Run: aimux run ${name}`);
           } else if (!options.auth) {
             console.log('  Auth skipped (--no-auth). Run: aimux auth login ' + name);
@@ -890,6 +909,10 @@ program
           }
           const hasAuth = existsSync(join(profilePath, adapter.credentialsFile()));
           if (hasAuth) {
+            // Self-heal profiles created before the seed existed: without the onboarding
+            // flag the next `aimux run` opens claude's first-run wizard and asks for an
+            // account again, right after this login succeeded.
+            if (p.cli === 'claude') seedClaudeOnboarding(profilePath);
             console.log(`✓ Profile '${resolved}' authenticated`);
           }
         } catch (err) {

--- a/src/core/apiProfile.test.ts
+++ b/src/core/apiProfile.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync, statSync, chmodSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, isAffirmative } from './apiProfile.js';
+import { writeProfileDotEnv, mergeProfileDotEnv, checkDotenvPermissions, isAffirmative, seedClaudeOnboarding, seedApiClaudeJson } from './apiProfile.js';
 import { parseDotenv } from './run.js';
 
 describe('isAffirmative', () => {
@@ -96,5 +96,31 @@ describe('checkDotenvPermissions', () => {
     chmodSync(join(dir, '.env'), 0o644);
     const warning = checkDotenvPermissions(dir);
     expect(warning).toContain('chmod 600');
+  });
+});
+
+describe('seedClaudeOnboarding', () => {
+  let dir: string;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'aimux-seed-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  it('marks onboarding complete so `run` does not re-open the first-run wizard', () => {
+    // Without this flag claude treats a fresh profile dir as a first run and shows its
+    // wizard — account step included — which reads as "the login was lost".
+    expect(seedClaudeOnboarding(dir)).toBe(true);
+    const seeded = JSON.parse(readFileSync(join(dir, '.claude.json'), 'utf-8'));
+    expect(seeded.hasCompletedOnboarding).toBe(true);
+    expect(statSync(join(dir, '.claude.json')).mode & 0o777).toBe(0o600);
+  });
+
+  it('never clobbers an existing .claude.json (real account state lives there)', () => {
+    const existing = { hasCompletedOnboarding: true, oauthAccount: { emailAddress: 'me@example.com' } };
+    writeFileSync(join(dir, '.claude.json'), JSON.stringify(existing));
+    expect(seedClaudeOnboarding(dir)).toBe(false);
+    expect(JSON.parse(readFileSync(join(dir, '.claude.json'), 'utf-8'))).toEqual(existing);
+  });
+
+  it('keeps the old exported name working for ./core consumers', () => {
+    expect(seedApiClaudeJson).toBe(seedClaudeOnboarding);
   });
 });

--- a/src/core/apiProfile.ts
+++ b/src/core/apiProfile.ts
@@ -270,12 +270,18 @@ export async function collectProviderCredentials(preset: ProviderPreset): Promis
 }
 
 /**
- * Seed a minimal `.claude.json` for an API profile so Claude Code skips its
- * first-run onboarding/OAuth flow and goes straight to the API endpoint
- * configured via env. No-op if the file already exists (never clobbers a real
- * one). Written chmod 600 alongside the profile's `.env`.
+ * Seed a minimal `.claude.json` so Claude Code skips its first-run onboarding.
+ *
+ * Needed by EVERY claude profile, not just API ones. A fresh profile dir has no
+ * `.claude.json`, so `hasCompletedOnboarding` is unset and claude opens the
+ * first-run wizard — which includes an account step. That reads as "I already
+ * logged in, why is it asking again?" even though `aimux auth login` wrote valid
+ * credentials: the credentials are fine, the onboarding flag is what's missing.
+ *
+ * No-op if the file already exists (never clobbers a real one). Written chmod 600
+ * alongside the profile's `.env`.
  */
-export function seedApiClaudeJson(profilePath: string): boolean {
+export function seedClaudeOnboarding(profilePath: string): boolean {
   const target = join(profilePath, '.claude.json');
   if (existsSync(target)) return false;
   writeFileSync(target, JSON.stringify({ hasCompletedOnboarding: true }, null, 2) + '\n', {
@@ -284,6 +290,10 @@ export function seedApiClaudeJson(profilePath: string): boolean {
   });
   return true;
 }
+
+/** @deprecated Renamed to `seedClaudeOnboarding` — it applies to every claude
+ *  profile, not only API ones. Kept so `./core` consumers keep compiling. */
+export const seedApiClaudeJson = seedClaudeOnboarding;
 
 /** Quote a dotenv value only when it contains characters that need it. */
 function serializeDotenvValue(value: string): string {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -66,6 +66,7 @@ export {
   writeProfileDotEnv,
   mergeProfileDotEnv,
   checkDotenvPermissions,
+  seedClaudeOnboarding,
   seedApiClaudeJson,
   API_MODEL_DEFAULTS,
   isAffirmative,


### PR DESCRIPTION
## The bug

`aimux auth login <profile>` completes, prints `✓ Profile authenticated`, and writes valid credentials. Then the very next `aimux run <profile>` asks for an account again.

Reported by a user of the published package, so this hits anyone adding their first extra profile.

## Root cause

The credentials were never the problem. A freshly created profile directory has no `.claude.json`, so `hasCompletedOnboarding` is unset and claude treats the launch as a **first run** — opening its onboarding wizard, which includes an account step. That reads as "my login was lost".

Verified directly rather than inferred: launching claude in a config dir holding valid credentials but no `.claude.json` leaves `hasCompletedOnboarding` unset afterwards — i.e. it was sitting at the wizard. `claude auth status` in the same dir reports `loggedIn: true`, confirming the credentials are fine. A profile that has been through the wizard once has the flag set, which is why the problem appears to "fix itself" after one manual re-login and was hard to pin down.

The seed for exactly this already existed in the codebase — `seedApiClaudeJson`, whose own docstring says it exists "so Claude Code skips its first-run onboarding/OAuth flow" — but it was wired only to the `--api` branch of `profile add`. OAuth profiles, the common case, never got it.

## The fix

- `profile add` seeds the onboarding flag for **every** claude profile, not just `--api` ones.
- `auth login` seeds it after a successful login, healing profiles created before this change.
- `run` seeds it for a claude profile that already has credentials. **Gated on the credentials file existing**, so a genuinely unauthenticated profile still gets its real login prompt instead of being silently pushed past it.
- An existing `.claude.json` is never overwritten — it holds real account state.
- `seedApiClaudeJson` → `seedClaudeOnboarding` (no longer API-specific). The old name stays exported as a deprecated alias so `./core` consumers keep compiling.

## Verification

- **308 tests pass**, `tsc` clean. New tests cover the seeded flag and `0600` mode, the never-clobber guarantee, and the alias.
- **On a real machine:** a newly added profile now gets `hasCompletedOnboarding: true` at creation (`Seeded .claude.json`), and a profile put back into the broken state — credentials present, `.claude.json` deleted — is healed by the next `aimux run`.

Bumps **0.22.0 → 0.22.1**.