### PR TITLE
fix: read macOS Keychain credentials so the 5h/7d limits column works

### DIFF
--- a/src/core/limits.test.ts
+++ b/src/core/limits.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import type { ProfileConfig } from '../types/index.js';
-import { parseRateLimitHeaders, parseCodexUsage, pctColor, probeError, rateLimitProfiles, formatResetAt, pickFreestProfile } from './limits.js';
+import { parseRateLimitHeaders, parseCodexUsage, pctColor, probeError, rateLimitProfiles, formatResetAt, pickFreestProfile, keychainService, classifyProfile } from './limits.js';
 
 // Real header keys captured from a live HTTP 200 probe (see plan spike result).
 const REAL = {
@@ -53,6 +53,61 @@ describe('parseRateLimitHeaders', () => {
     expect(r.fiveHourPct).toBe(30);
     expect(r.weeklyPct).toBeNull();
     expect(r.weeklyResetsAt).toBeUndefined();
+  });
+});
+
+describe('keychainService', () => {
+  it('uses the bare service name for the default config dir', () => {
+    expect(keychainService(join(homedir(), '.claude'))).toBe('Claude Code-credentials');
+  });
+
+  // Pinned rather than recomputed: restating the hash in the test would assert
+  // nothing, and a drifted naming scheme is indistinguishable from "not logged in".
+  it('suffixes any other config dir with the first 8 hex of its sha256', () => {
+    expect(keychainService('/Users/example/.aimux/profiles/work')).toBe(
+      'Claude Code-credentials-8c2e5287',
+    );
+  });
+
+  it('gives two profiles two different service names, so one cannot read the other\'s quota', () => {
+    expect(keychainService('/Users/example/.aimux/profiles/work')).not.toBe(
+      keychainService('/Users/example/.aimux/profiles/personal'),
+    );
+  });
+});
+
+describe('classifyProfile', () => {
+  let dir: string;
+
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'aimux-classify-')); });
+  afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+  const never = () => false;
+  const always = () => true;
+
+  // The regression this guards: on macOS there is no .credentials.json to find, so
+  // a logged-in profile graded 'none' here is dropped from the probe set before its
+  // token is ever read, and its 5h/7d column renders a permanent em-dash.
+  it('grades a non-source profile with Keychain credentials as oauth', () => {
+    expect(classifyProfile({ cli: 'claude', path: dir }, dir, always)).toBe('oauth');
+  });
+
+  it('still grades a profile with neither a credentials file nor a Keychain entry as none', () => {
+    expect(classifyProfile({ cli: 'claude', path: dir }, dir, never)).toBe('none');
+  });
+
+  it('does not consult the Keychain for codex, whose token lives in auth.json', () => {
+    expect(classifyProfile({ cli: 'codex', path: dir }, dir, always)).toBe('none');
+  });
+
+  it('still prefers a credentials file when one exists', () => {
+    writeFileSync(join(dir, '.credentials.json'), '{}');
+    expect(classifyProfile({ cli: 'claude', path: dir }, dir, never)).toBe('oauth');
+  });
+
+  it('still classifies a 3rd-party API profile as api, ahead of any credential lookup', () => {
+    writeFileSync(join(dir, '.env'), 'ANTHROPIC_BASE_URL=https://api.example.com\n');
+    expect(classifyProfile({ cli: 'claude', path: dir }, dir, always)).toBe('api');
   });
 });
 

--- a/src/core/limits.ts
+++ b/src/core/limits.ts
@@ -1,4 +1,7 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { ProfileConfig } from '../types/index.js';
 import { loadProfileEnv } from './run.js';
@@ -64,18 +67,71 @@ export function parseRateLimitHeaders(
   };
 }
 
+/** A Keychain lookup is a subprocess; cap it so a locked Keychain (which prompts)
+ *  cannot hang a status table. */
+const KEYCHAIN_TIMEOUT_MS = 4000;
+
+/**
+ * The Keychain service name Claude Code stores a config dir's credentials under:
+ * the bare service for the default `~/.claude`, otherwise suffixed with the first
+ * 8 hex of the path's sha256. Exported because the naming is the part that can
+ * silently drift, and a wrong name is indistinguishable from "not logged in".
+ */
+export function keychainService(profilePath: string): string {
+  const base = 'Claude Code-credentials';
+  if (profilePath === join(homedir(), '.claude')) return base;
+  return `${base}-${createHash('sha256').update(profilePath).digest('hex').slice(0, 8)}`;
+}
+
+/** Whether the login Keychain holds claude credentials for this config dir. */
+export function hasKeychainCredentials(profilePath: string): boolean {
+  if (process.platform !== 'darwin') return false;
+  try {
+    execFileSync('security', ['find-generic-password', '-s', keychainService(profilePath)], {
+      timeout: KEYCHAIN_TIMEOUT_MS,
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Read the OAuth token macOS keeps in the login Keychain rather than on disk. */
+function readKeychainToken(profilePath: string): string | null {
+  if (process.platform !== 'darwin') return null;
+  try {
+    const raw = execFileSync(
+      'security',
+      ['find-generic-password', '-s', keychainService(profilePath), '-w'],
+      { encoding: 'utf-8', timeout: KEYCHAIN_TIMEOUT_MS, stdio: ['ignore', 'pipe', 'ignore'] },
+    );
+    return JSON.parse(raw)?.claudeAiOauth?.accessToken ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Classify how a profile authenticates, mirroring StatusView.checkAuth's first
  * two branches (without the slow spawn probe): a non-source profile carrying a
  * 3rd-party endpoint env is `api`; a profile with stored OAuth credentials is
  * `oauth`; otherwise `none`. Only `oauth` profiles get a rate-limit probe.
  */
-export function classifyProfile(profile: ProfileConfig, profilePath: string): ProfileKind {
+export function classifyProfile(
+  profile: ProfileConfig,
+  profilePath: string,
+  hasKeychain: (profilePath: string) => boolean = hasKeychainCredentials,
+): ProfileKind {
   if (!profile.is_source) {
     const env = loadProfileEnv(profile, profilePath);
     if (env.ANTHROPIC_AUTH_TOKEN || env.ANTHROPIC_BASE_URL) return 'api';
   }
   if (existsSync(join(profilePath, adapterFor(profile.cli).credentialsFile()))) return 'oauth';
+  // On macOS there is no credentials file to find — claude keeps the token in the
+  // login Keychain. Without this branch a logged-in non-source profile grades
+  // 'none' and is dropped from the probe set before its token is ever read.
+  if ((profile.cli ?? 'claude') === 'claude' && hasKeychain(profilePath)) return 'oauth';
   return profile.is_source ? 'oauth' : 'none';
 }
 
@@ -178,10 +234,12 @@ function readOAuthToken(profilePath: string): string | null {
   try {
     const raw = JSON.parse(readFileSync(join(profilePath, '.credentials.json'), 'utf-8'));
     const oauth = raw.claudeAiOauth ?? raw.claude_ai_oauth ?? raw;
-    return oauth.accessToken ?? oauth.access_token ?? null;
+    const token = oauth.accessToken ?? oauth.access_token ?? null;
+    if (token) return token;
   } catch {
-    return null;
+    // A missing credentials file is the normal case on macOS, not a failure.
   }
+  return readKeychainToken(profilePath);
 }
 
 /** Read codex's stored ChatGPT tokens. Unlike claude, the account id is part of


### PR DESCRIPTION
## Problem

On macOS, `aimux status` never shows a limit figure for any profile, and misdiagnoses the source profile as logged out:

```
  NAME    AUTH        SHARED      USED 5H/7D
  main    ✓ oauth     (source)    login?
▸ personal ✓ oauth    29/32       —

login? — stored token expired for main. The CLI refreshes it on its next run: `aimux run main`.
```

Both profiles are logged in and both tokens are valid. The footnote sends the user to re-authenticate something that isn't broken.

## Root cause

Claude Code stores OAuth credentials in the **login Keychain** on macOS, not in `<profile>/.credentials.json`. Two functions in `src/core/limits.ts` assume the file, and **both** have to change — fixing either alone leaves the column half blank:

| Function | Failure | Symptom |
|---|---|---|
| `readOAuthToken` | No Keychain fallback → no token is ever found → `probeError(...)` returns `auth` | source profile renders `login?` |
| `classifyProfile` | A non-source profile with no credentials *file* grades `none`; `rateLimitProfiles` drops it before a token is ever read | other profiles render `—` |

`classifyProfile` is the less obvious half: the profile is excluded from the probe set, so `readOAuthToken` is never reached for it even once fixed.

## Fix

Derive the Keychain service name — the bare `Claude Code-credentials` for the default `~/.claude`, otherwise suffixed with the first 8 hex of the config dir path's sha256 — and use it as a fallback in both places.

- Guarded on `process.platform === 'darwin'`, so no subprocess is spawned on Linux.
- `execFileSync` calls are time-limited (4s): a locked Keychain prompts, and an unbounded call there would hang the status table.
- The credentials **file** still takes precedence, so Linux and any older file-based install are unaffected.
- Only `claude` profiles consult the Keychain; codex keeps its token in `auth.json`.
- `classifyProfile` takes the Keychain check as an injectable third parameter (defaulted), matching the `deps`-injection idiom already used in `handoff.ts`, so the branch is testable without a real Keychain entry.

## After

```
  NAME    AUTH        SHARED      USED 5H/7D
  main    ✓ oauth     (source)    3% / 94%
▸ personal ✓ oauth    29/32       64% / 13%
```

Verified against a real two-profile macOS install; the figures match the `anthropic-ratelimit-unified-*` response headers directly, and `--no-limits` still short-circuits.

## Tests

8 added, `339 passed (26 files)`, typecheck clean.

- `keychainService` — bare name for the default dir; the sha256 suffix **pinned to a literal** rather than recomputed in the assertion (restating the hash would assert nothing, and a drifted scheme is indistinguishable from "not logged in"); distinct dirs get distinct names, so one profile can't read another's quota.
- `classifyProfile` — the Keychain branch, plus regression cover that a credentials file still wins, that a profile with neither still grades `none`, that codex doesn't consult the Keychain, and that a 3rd-party API profile is still classified `api` ahead of any credential lookup.

Mutation-checked: removing only the `classifyProfile` Keychain branch fails exactly the one test that covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)